### PR TITLE
Fixed repo info for Gitlab does not support group nesting

### DIFF
--- a/workspaces/aws/.changeset/serious-cougars-whisper.md
+++ b/workspaces/aws/.changeset/serious-cougars-whisper.md
@@ -1,0 +1,7 @@
+---
+'@alithya-oss/plugin-aws-apps-backend': patch
+'@alithya-oss/plugin-aws-apps-common': patch
+'@alithya-oss/plugin-aws-apps': patch
+---
+
+Fixed repo info for Gitlab does not support group nesting. (https://github.com/awslabs/harmonix/pull/140)

--- a/workspaces/aws/plugins/aws-apps-backend/src/api/AwsPlatform.ts
+++ b/workspaces/aws/plugins/aws-apps-backend/src/api/AwsPlatform.ts
@@ -486,7 +486,7 @@ export class AwsAppsPlatformApi {
     let resultBody;
 
     if (this.gitProvider === GitProviders.GITLAB) {
-      resultBody = await result.value.json();
+      resultBody = result.value;
     } else if (this.gitProvider === GitProviders.GITHUB) {
       resultBody = result.message;
     }

--- a/workspaces/aws/plugins/aws-apps-backend/src/api/GitlabApiClient.ts
+++ b/workspaces/aws/plugins/aws-apps-backend/src/api/GitlabApiClient.ts
@@ -24,7 +24,7 @@ export class GitLabAPI implements ISCMBackendAPI {
       groupName = gitRepoName.split('/')[0];
       repoName = gitRepoName.split('/')[1];
     } else {
-      groupName = '';
+      groupName = gitProjectGroup;
       repoName = gitRepoName;
     }
     const url = `https://${gitHost}/api/v4/projects?search=${repoName}`;
@@ -182,7 +182,7 @@ export class GitLabAPI implements ISCMBackendAPI {
       isSuccess: true,
       message: `Retrieved file content successfully`,
       httpResponse: result.status,
-      value: resultBody.content,
+      value: Buffer.from(resultBody.content, 'base64').toString(),
     };
   }
 

--- a/workspaces/aws/plugins/aws-apps-common/src/utils/git-util.ts
+++ b/workspaces/aws/plugins/aws-apps-common/src/utils/git-util.ts
@@ -41,36 +41,34 @@ export const getRepoInfo = (entity: Entity): IRepositoryInfo => {
   //     throw Error("Unsupported git provider: " + entity.metadata["gitProvider"])
   // }
 
+  let projectSlugArray: string[];
+
   switch (gitProvider) {
     case GitProviders.GITLAB:
+      projectSlugArray = entity.metadata.annotations
+        ? entity.metadata.annotations['gitlab.com/project-slug']
+            ?.toString()
+            .split('/')
+        : [];
       return {
         gitProvider,
         gitHost: entity.metadata.annotations
           ? entity.metadata.annotations['gitlab.com/instance']?.toString()
           : '',
-        gitRepoName: entity.metadata.annotations
-          ? entity.metadata.annotations['gitlab.com/project-slug']?.toString()
-          : '',
-        gitProjectGroup: entity.metadata.annotations
-          ? entity.metadata.annotations['gitlab.com/project-slug']
-              ?.toString()
-              .split('/')[0]
-          : '',
+        gitRepoName: projectSlugArray.pop() || '', // get last element of path for the repository name or empty string if the array is empty
+        gitProjectGroup: projectSlugArray.join('/'), // re-join the remainder of the array to get the namespace
         isPrivate: true,
       };
     case GitProviders.GITHUB:
+      projectSlugArray = entity.metadata.annotations
+        ? entity.metadata.annotations['github.com/project-slug']
+            ?.toString()
+            .split('/')
+        : [];
       return {
         gitHost: 'github.com',
-        gitRepoName: entity.metadata.annotations
-          ? entity.metadata.annotations['github.com/project-slug']
-              ?.toString()
-              .split('/')[1]
-          : '',
-        gitOrganization: entity.metadata.annotations
-          ? entity.metadata.annotations['github.com/project-slug']
-              ?.toString()
-              .split('/')[0]
-          : '',
+        gitRepoName: projectSlugArray[1], // get last element of the array (repo name)
+        gitOrganization: projectSlugArray[0], // get first element of the array (organization)
         gitProvider,
         isPrivate: true,
       };

--- a/workspaces/aws/plugins/aws-apps/src/components/AwsEnvironmentProviderCard/AwsEnvironmentProviderCard.tsx
+++ b/workspaces/aws/plugins/aws-apps/src/components/AwsEnvironmentProviderCard/AwsEnvironmentProviderCard.tsx
@@ -165,7 +165,6 @@ const AwsEnvironmentProviderCard = ({
     };
 
     const repoInfo = getRepoInfo(entity);
-    repoInfo.gitProjectGroup = 'aws-environments';
 
     const params = {
       repoInfo,

--- a/workspaces/aws/plugins/aws-apps/src/components/DeleteEnvironmentCard/DeleteEnvironmentCard.tsx
+++ b/workspaces/aws/plugins/aws-apps/src/components/DeleteEnvironmentCard/DeleteEnvironmentCard.tsx
@@ -41,7 +41,6 @@ const DeleteEnvironmentPanel = ({
 
   const [disabled, setDisabled] = useState(false);
   const repoInfo = getRepoInfo(entity);
-  repoInfo.gitProjectGroup = 'aws-environments';
 
   const deleteRepo = () => {
     api

--- a/workspaces/aws/plugins/aws-apps/src/components/DeleteProviderCard/DeleteProviderCard.tsx
+++ b/workspaces/aws/plugins/aws-apps/src/components/DeleteProviderCard/DeleteProviderCard.tsx
@@ -52,7 +52,6 @@ const DeleteProviderPanel = ({
 
   const [disabled, setDisabled] = useState(false);
   const repoInfo = getRepoInfo(entity);
-  repoInfo.gitProjectGroup = 'aws-providers';
 
   const deleteRepo = () => {
     api

--- a/workspaces/aws/yarn.lock
+++ b/workspaces/aws/yarn.lock
@@ -40934,11 +40934,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>":
   version: 5.7.2
-  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=cef18b"
+  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/ff27fc124bceb8969be722baa38af945b2505767cf794de3e2715e58f61b43780284060287d651fcbbdfb6f917f4653b20f4751991f17e0706db389b9bb3f75d
+  checksum: 10/d75ca10141afc64fd3474b41a8b082b640555bed388d237558aed64e5827ddadb48f90932c7f4205883f18f5bcab8b6a739a2cfac95855604b0dfeb34bc2f3eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/awslabs/harmonix/pull/140

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

https://github.com/awslabs/harmonix/pull/140

* Modify `git-util.ts` to support hosting Harmonix reference repositories in a nested Gitlab group
* Remove places where groups were hardcoded
Fixes in `GitlabApi::getFileContents` (parse base 64) and `GitlabApi::commitContent` (redundant json() call)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))