### PR TITLE
OSS-8 docs(mcp-chat): OpenSpec proposal for the Assistant UI prompt page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,13 @@ name: CI
 
 on:
   pull_request:
+    # OpenSpec artifacts live at the repo root, outside every workspace. A PR that
+    # touches only them produces an empty workspace matrix, which leaves `ci` and
+    # `verify` skipped and makes the `result` gate below fail even though there is
+    # nothing to build or test. Skip the whole workflow for those PRs instead.
+    # A PR that touches openspec/ *and* a workspace still triggers normally.
+    paths-ignore:
+      - 'openspec/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/openspec/changes/add-mcp-chat-prompt-page/.openspec.yaml
+++ b/openspec/changes/add-mcp-chat-prompt-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/add-mcp-chat-prompt-page/design.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/design.md
@@ -4,7 +4,7 @@ See `proposal.md` — Why. What shapes the approach here is the shape of the
 existing transport and of the library, both verified against the code and the
 published package rather than from documentation:
 
-**The transport is request/response, not a stream.**
+**The existing transport is request/response; a streaming one is added.**
 `McpChatApi.sendChatMessage(messages, enabledTools, signal, conversationId)`
 returns `Promise<ChatResponse>`. `POST /chat` in
 `plugins/mcp-chat-backend/src/routes/chatRoutes.ts` calls
@@ -12,16 +12,30 @@ returns `Promise<ChatResponse>`. `POST /chat` in
 `{ role: 'assistant', content, toolResponses, toolsUsed, conversationId }`.
 Tool calls run **server-side**, inside `processQuery`, and are reported after the
 fact as `ToolExecutionResult[]` — `{ id, name, arguments, result, serverId }`.
-The frontend never executes a tool and never observes one starting.
+The frontend never executes a tool.
+
+Streaming is in scope for this change, so that endpoint is joined by a
+server-sent-event one. The constraint that shapes the design is the provider
+layer: `LLMProvider` (`plugins/mcp-chat-node/src/LLMProvider.ts`) is an **abstract
+class** whose `sendMessage` returns a complete `ChatResponse`, and there are
+**nine** provider modules extending it (`openai`, `anthropic`, `amazon-bedrock`,
+`gemini`, `ollama`, `litellm`, `azure-openai`, `openai-responses`,
+`agentgateway`). Adding an abstract streaming method would break all nine at
+once. `QueryProcessor.processQuery` also has two paths — the tool-calling loop and
+a separate `processQueryWithResponsesApi` for providers reporting
+`supportsNativeMcp()`.
 
 **The library at `@assistant-ui/react@0.15.16`.** `useExternalStoreRuntime` and
 `ExternalStoreAdapter` re-export from `@assistant-ui/core@0.3.15`. On
 `ExternalStoreAdapter`, only `onNew` is required. `unstable_enableToolInvocations`
 defaults to `false`, which is what we want: the runtime then does not drive
 client-side tool callbacks and simply renders the tool-call parts we put in
-`messages`. The package ships **no CSS** and pulls in no Tailwind — its
-primitives are unstyled Radix wrappers, so it composes with CSS modules over BUI
-tokens.
+`messages`. `ThreadMessageLike` accepts a `status`, and `MessageStatus` covers
+`{ type: 'running' }`, `{ type: 'complete', reason }` and
+`{ type: 'incomplete', reason: 'cancelled' | 'error' | ... }` — which is how a
+partially streamed turn is represented. The package ships **no CSS** and pulls in
+no Tailwind — its primitives are unstyled Radix wrappers, so it composes with CSS
+modules over BUI tokens.
 
 **`adapters.threadList` is flagged unstable.** In
 `external-store-adapter.d.ts`, the `threadList` slot itself and its `threadId`,
@@ -39,7 +53,11 @@ not `@backstage/core-components` or Material UI icons.
 
 **Goals**
 
-- Reuse the existing transport untouched; the adapter is the only new seam.
+- Add streaming without touching the existing `POST /chat` contract or the
+  existing page.
+- Keep the nine provider modules compiling and working untouched, so streaming can
+  be adopted per provider instead of in one flag-day change.
+- Give the frontend a single code path whether or not the active provider streams.
 - Keep the new page's failure modes independent of the existing page's.
 - Depend only on stable Assistant UI surface.
 - Keep the reduced side panel's data layer as existing hooks, so panel behaviour
@@ -51,27 +69,93 @@ not `@backstage/core-components` or Material UI icons.
   presentation component extracted between old and new page. Duplicated markup
   is accepted for this change: the old components are Material UI and the new
   ones are BUI, so a shared component would have to satisfy both.
-- No change to `McpChatApi`, `src/types.ts`, or any backend package.
+- No change to the behaviour of `sendChatMessage` or `POST /chat`, and no
+  database or conversation-schema change.
+- No native incremental output implemented in the nine provider modules here —
+  only the seam and the fallback.
 - No Assistant UI Cloud, no `AssistantCloud`, no remote thread list.
+- No WebSocket transport.
 
 ## Decisions
 
+### Transport: server-sent events on a new route
+
+A new `POST /chat/stream` sits beside `POST /chat`, taking the same body and
+answering `text/event-stream`. SSE is chosen over the alternatives because the
+traffic is one-directional (the client sends one request, then only reads), it
+rides the existing HTTP stack and Backstage auth with no new infrastructure, and
+`fetchApi.fetch` already gives the frontend a readable body stream plus an
+`AbortSignal` for cancellation.
+
+Rejected: WebSockets (bidirectional machinery for a one-way flow, plus proxy and
+auth complications for no gain); chunked JSON lines over the existing route
+(would change `POST /chat`'s response type, breaking the current page); polling
+(no incremental output).
+
+The event names and payloads are fixed by
+`specs/mcp-chat/chat-streaming/spec.md` — a text fragment event, a tool-call
+event, a tool-result event, and exactly one terminal completion-or-failure event.
+Shared payload types live in `mcp-chat-common` so backend and frontend cannot
+drift.
+
+### Provider streaming: optional method on the base class, never abstract
+
+`LLMProvider` is abstract and nine modules extend it, so a new `abstract`
+streaming method would fail to compile in all nine at once. Instead the base class
+gains a **concrete** `streamMessage` whose default implementation awaits the
+existing `sendMessage` and emits the whole reply as one fragment, plus a
+`supportsStreaming()` returning `false` by default. A module opts in by overriding
+both.
+
+This is what lets the capability ship now and be honest about it: the endpoint and
+its contract exist for every provider today, the frontend has one code path, and
+each module can gain native streaming later without touching the route, the
+adapter or the page. `supportsStreaming()` is surfaced on provider status so the
+UI can distinguish real streaming from the fallback rather than pretending.
+
+The `processQueryWithResponsesApi` path used by `supportsNativeMcp()` providers
+keeps returning a complete response and is served by the same fallback, so
+native-MCP providers are covered from day one without that path being rewritten
+here.
+
+Rejected: making the method abstract and updating nine modules in one change
+(large blast radius, and it would block the frontend on provider work);
+frontend-side fake streaming that chunks a complete reply for visual effect
+(dishonest — it would report streaming while nothing streams, and the spec's
+capability-reporting requirement exists precisely to avoid that).
+
+### Tool events during a run
+
+The tool-calling loop in `QueryProcessor` already knows when it is about to invoke
+a tool and when the result lands, so the streaming variant emits a tool-call event
+before invoking and a tool-result event after, correlated by the invocation id.
+That is what lets the page show an invocation as running before its outcome
+exists, which the non-streaming path could never express.
+
+A failed or timed-out tool produces a tool-result marked failed and the run
+continues to its terminal event, matching the current behaviour where a tool
+failure does not abort the reply.
+
 ### Runtime: `useExternalStoreRuntime`, not `useLocalRuntime`
 
-`useLocalRuntime` expects a `ChatModelAdapter` that yields
-`ChatModelRunResult` updates — it is built for a model call the frontend drives
-and can stream from. Our backend performs the whole provider-plus-tools cycle
-server-side and answers once, and conversation persistence is already the
-backend's job, keyed by `conversationId`. `useExternalStoreRuntime` fits that:
-React state remains the single source of truth for the message list, the runtime
-renders it, and each handler maps onto one transport call. It is also what makes
-the "selecting an existing conversation" requirement cheap — loading a stored
-conversation is a `setState`, not a runtime migration.
+`useLocalRuntime` takes a `ChatModelAdapter` whose `run` may return
+`AsyncGenerator<ChatModelRunResult, void>` — the idiomatic streaming shape, and on
+the face of it the obvious choice now that we stream. It is still not the right
+fit: it moves the message list inside the runtime, whereas two spec'd behaviours
+need it in React state that the page owns — selecting a stored conversation
+replaces the whole list, and the reduced side panel drives that selection. With
+`useLocalRuntime` that becomes `ExportedMessageRepository` import gymnastics on
+every selection.
 
-Rejected: `useLocalRuntime` (would need a fake streaming adapter over a
-non-streaming call, and would duplicate persistence);
-`useAssistantTransportRuntime` / `AssistantCloud` (assume protocols the backend
-does not speak).
+`useExternalStoreRuntime` keeps React state as the single source of truth: the
+stream consumer appends each fragment to the last assistant turn's text and marks
+it `status: { type: 'running' }`, flipping to `complete` on the terminal event and
+`incomplete` with reason `error` or `cancelled` otherwise. Rendering follows from
+state, so streaming needs no runtime concept the adapter does not already have.
+Conversation persistence also stays the backend's job, keyed by `conversationId`.
+
+Rejected: `useLocalRuntime` (above); `useAssistantTransportRuntime` /
+`AssistantCloud` (assume protocols the backend does not speak).
 
 ### Handler matrix
 
@@ -82,13 +166,13 @@ from the one sketched in the parent issue, for reasons given below.
 | ---------------------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `messages`                                     | yes                   | React state of the converted turn list                                                                            |
 | `convertMessage`                               | yes                   | our `Message` view-model → `ThreadMessageLike`                                                                    |
-| `isRunning`                                    | yes                   | request-in-flight flag, drives the running indicator                                                              |
+| `isRunning`                                    | yes                   | true from submit until the terminal event, drives the running indicator                                           |
 | `isLoading`                                    | yes                   | true while a stored conversation is being fetched                                                                 |
-| `onNew`                                        | yes (required)        | append user turn, then `sendChatMessage`                                                                          |
+| `onNew`                                        | yes (required)        | append user turn, then consume the event stream, updating state per event                                         |
 | `setMessages`                                  | yes                   | lets the runtime rewrite the list — **required for cancel and for branch switching to survive the next snapshot** |
-| `onEdit`                                       | yes                   | truncate to the edited turn, re-run from it                                                                       |
-| `onReload`                                     | yes                   | re-run from a `parentId`, producing another branch                                                                |
-| `onCancel`                                     | yes                   | `AbortController.abort()`, then drop the trailing user turn                                                       |
+| `onEdit`                                       | yes                   | truncate to the edited turn, re-stream from it                                                                    |
+| `onReload`                                     | yes                   | re-stream from a `parentId`, producing another branch                                                             |
+| `onCancel`                                     | yes                   | `AbortController.abort()`, closing the stream, then drop the partial turn                                         |
 | `onDelete`                                     | no                    | not in the spec; no per-message delete affordance                                                                 |
 | `onAddToolResult`                              | **no**                | see below                                                                                                         |
 | `unstable_enableToolInvocations`               | **no** (left `false`) | tools run server-side                                                                                             |
@@ -99,8 +183,8 @@ from the one sketched in the parent issue, for reasons given below.
 assumption. That handler exists so a _client-side_ tool can hand its result back
 to the runtime; the type doc states results flow through it "from `execute()`
 returning, or from `streamCall` resolving". In `mcp-chat` every tool executes
-server-side and its result is already inside the response we convert into
-message parts, so nothing would ever call it. Wiring it would be dead code, and
+server-side and its result arrives in the stream we convert into message parts,
+so nothing would ever call it. Wiring it would be dead code, and
 enabling the tracker that drives it (`unstable_enableToolInvocations: true`)
 would make the runtime try to dispatch our server-side tool calls a second time.
 
@@ -109,16 +193,33 @@ it, "cancelling a run leaves a trailing user message in the thread and the
 composer untouched". Since cancel is a spec'd scenario, `setMessages` is
 required to satisfy it.
 
-### Message conversion
+### Message conversion and streaming state
 
 `convertMessage` maps one view-model message to a `ThreadMessageLike`. An
 assistant turn's `content` array is built as: one `{ type: 'text', text }` part
-for the reply, preceded by one `{ type: 'tool-call', toolCallId, toolName, args,
-result, isError }` part per `ToolExecutionResult` — `id` → `toolCallId`, `name` →
-`toolName`, `arguments` → `args`, `result` → `result`. `ToolExecutionResult` has
-no error flag, so `isError` is derived from the result payload; the check lives
-in one helper so it can be replaced if the backend later reports errors
-explicitly.
+carrying the text accumulated so far, preceded by one
+`{ type: 'tool-call', toolCallId, toolName, args, result, isError }` part per
+invocation — `id` → `toolCallId`, `name` → `toolName`, `arguments` → `args`,
+`result` → `result`.
+
+Streaming makes the turn's lifecycle explicit through `ThreadMessageLike.status`:
+
+- fragments still arriving → `{ type: 'running' }`
+- terminal completion → `{ type: 'complete', reason: 'stop' }`
+- terminal failure → `{ type: 'incomplete', reason: 'error' }`, keeping whatever
+  text had arrived, which is what the spec's "failure after partial output"
+  scenario requires
+- cancelled → `{ type: 'incomplete', reason: 'cancelled' }` before the partial
+  turn is dropped
+
+A tool-call part is written as soon as the tool-call event arrives, with `result`
+absent — that absence is what the tool UI renders as "still running" — and is
+filled in place, keyed by `toolCallId`, when its tool-result event lands. Keying
+by id is what keeps a resolving invocation from appearing twice.
+
+The backend's tool-result event carries an explicit failure flag, so `isError` is
+read from the event rather than inferred from the payload as the non-streaming
+path would have required.
 
 This is the seam that lets tool rendering meet its spec without any client-side
 tool machinery: the parts are already in the message, and `makeAssistantToolUI`
@@ -191,12 +292,24 @@ nothing else in the workspace is tested against React 19.
 
 ## Risks / Trade-offs
 
-- **No token streaming, while the parent issue's acceptance criteria ask for
-  streaming** → Cannot be resolved in this change: the backend answers once.
-  Mitigated by a running indicator and working cancel, so the page never looks
-  frozen. Escalated rather than absorbed silently — the spec states the
-  non-requirement explicitly and the proposal records it as deferred, so adding a
-  streaming endpoint later changes no other requirement.
+- **Streaming ships as a contract before most providers implement it** → Every
+  provider is reachable through the endpoint from day one via the base-class
+  fallback, so nothing is broken; but a user on a non-streaming provider sees the
+  reply arrive in one piece. Mitigated by surfacing `supportsStreaming()` on
+  provider status so the UI states which mode is active rather than implying
+  token-by-token output everywhere. Per-provider work is tracked as follow-up.
+- **The streaming path duplicates the tool-calling loop's logic** → Two code paths
+  through `QueryProcessor` can drift, so tool filtering by enabled server and the
+  system-prompt injection must be factored into helpers both paths call rather than
+  copied. Tests cover both paths against the same fixtures.
+- **SSE through proxies and load balancers can buffer** → Set the conventional
+  no-buffering response headers and keep events small. If an adopter's ingress
+  still buffers, the fallback behaviour (whole reply in one fragment) is what they
+  observe — degraded, not broken.
+- **A dropped connection mid-run could orphan provider or tool work** → The route
+  ties an `AbortController` to client disconnect, and the spec forbids starting new
+  tool invocations for a cancelled run. A tool already in flight still runs to its
+  timeout; that is accepted.
 - **Assistant UI is pre-1.0 (`0.15.16`)** → Depend only on non-`unstable_`,
   non-deprecated surface (this is what rules out `adapters.threadList`). Pin an
   exact-minor range and treat upgrades as reviewed changes.
@@ -204,21 +317,29 @@ nothing else in the workspace is tested against React 19.
   `yarn dedupe` is run and `yarn dedupe --check` gated in CI. `zod` and `zustand`
   arriving in the workspace risks duplicate resolutions; dedupe before `tsc:full`,
   since duplicate copies of one library surface as spurious type errors.
-- **Two chat UIs to maintain** → Accepted and time-boxed: retiring the old page
-  is a separate decision once the new one has adopter feedback.
+- **Two chat UIs to maintain, now over two transports** → Accepted and time-boxed:
+  retiring the old page is a separate decision once the new one has adopter
+  feedback. The old page stays on `POST /chat`, which this change does not touch.
 - **Duplicated panel presentation between old and new page** → Accepted: the data
   layer (`useMcpServers`, `useProviderStatus`, `useConversations`) is shared, only
   the markup is not, because the two pages target different component libraries.
-- **`isError` for a tool call is inferred, not reported** → Isolated in one
-  helper, so a future backend field replaces one function.
 
 ## Migration Plan
 
-Additive and adopter-driven. The new page ships behind its own route and is not
-mounted automatically; adopters add its extension when they want it. Rollback for
-an adopter is removing the mount — the existing page is untouched, so there is no
-data or route migration and nothing to reverse on the backend. The only change
-visible to an adopter who does nothing is the narrowed React peer range.
+Additive and adopter-driven, on both sides. The new page ships behind its own
+route and is not mounted automatically; the streaming endpoint is a new route that
+nothing else calls. Adopters who upgrade without mounting the page get the new
+endpoint and keep the old behaviour untouched.
+
+Deployment order matters in one direction only: the backend package must be
+deployed before the new page is mounted, since the page calls the new route. An
+adopter who mounts the page against an older backend gets a 404 on the streaming
+route — the page's transport-failure requirement covers that, showing an error
+with a retry rather than hanging.
+
+Rollback is removing the mount; the existing page and `POST /chat` are unchanged,
+so there is no data, schema or route migration to reverse. The only change visible
+to an adopter who does nothing is the narrowed React peer range.
 
 ## Open Questions
 

--- a/openspec/changes/add-mcp-chat-prompt-page/design.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/design.md
@@ -1,0 +1,230 @@
+## Context
+
+See `proposal.md` — Why. What shapes the approach here is the shape of the
+existing transport and of the library, both verified against the code and the
+published package rather than from documentation:
+
+**The transport is request/response, not a stream.**
+`McpChatApi.sendChatMessage(messages, enabledTools, signal, conversationId)`
+returns `Promise<ChatResponse>`. `POST /chat` in
+`plugins/mcp-chat-backend/src/routes/chatRoutes.ts` calls
+`mcpClientService.processQuery(...)` and only then answers
+`{ role: 'assistant', content, toolResponses, toolsUsed, conversationId }`.
+Tool calls run **server-side**, inside `processQuery`, and are reported after the
+fact as `ToolExecutionResult[]` — `{ id, name, arguments, result, serverId }`.
+The frontend never executes a tool and never observes one starting.
+
+**The library at `@assistant-ui/react@0.15.16`.** `useExternalStoreRuntime` and
+`ExternalStoreAdapter` re-export from `@assistant-ui/core@0.3.15`. On
+`ExternalStoreAdapter`, only `onNew` is required. `unstable_enableToolInvocations`
+defaults to `false`, which is what we want: the runtime then does not drive
+client-side tool callbacks and simply renders the tool-call parts we put in
+`messages`. The package ships **no CSS** and pulls in no Tailwind — its
+primitives are unstyled Radix wrappers, so it composes with CSS modules over BUI
+tokens.
+
+**`adapters.threadList` is flagged unstable.** In
+`external-store-adapter.d.ts`, the `threadList` slot itself and its `threadId`,
+`onSwitchToNewThread` and `onSwitchToThread` members each carry
+`@deprecated This API is still under active development and might change without notice.`
+Its thread model is `{ status: 'regular' | 'archived', id, remoteId, externalId,
+title, custom }` — no search, and no third state to carry "starred".
+
+**Backstage constraints.** Workspace `mcp-chat` pins Backstage `1.40.0`, which
+requires React 18; the workspace lockfile already resolves `react@18.3.1`. The
+target for new UI in this repository is `@backstage/ui` plus `@remixicon/react`,
+not `@backstage/core-components` or Material UI icons.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Reuse the existing transport untouched; the adapter is the only new seam.
+- Keep the new page's failure modes independent of the existing page's.
+- Depend only on stable Assistant UI surface.
+- Keep the reduced side panel's data layer as existing hooks, so panel behaviour
+  stays consistent between the two pages.
+
+**Non-Goals**
+
+- No refactor of `ChatContainer`, `RightPane` or `ChatPage`, and no shared
+  presentation component extracted between old and new page. Duplicated markup
+  is accepted for this change: the old components are Material UI and the new
+  ones are BUI, so a shared component would have to satisfy both.
+- No change to `McpChatApi`, `src/types.ts`, or any backend package.
+- No Assistant UI Cloud, no `AssistantCloud`, no remote thread list.
+
+## Decisions
+
+### Runtime: `useExternalStoreRuntime`, not `useLocalRuntime`
+
+`useLocalRuntime` expects a `ChatModelAdapter` that yields
+`ChatModelRunResult` updates — it is built for a model call the frontend drives
+and can stream from. Our backend performs the whole provider-plus-tools cycle
+server-side and answers once, and conversation persistence is already the
+backend's job, keyed by `conversationId`. `useExternalStoreRuntime` fits that:
+React state remains the single source of truth for the message list, the runtime
+renders it, and each handler maps onto one transport call. It is also what makes
+the "selecting an existing conversation" requirement cheap — loading a stored
+conversation is a `setState`, not a runtime migration.
+
+Rejected: `useLocalRuntime` (would need a fake streaming adapter over a
+non-streaming call, and would duplicate persistence);
+`useAssistantTransportRuntime` / `AssistantCloud` (assume protocols the backend
+does not speak).
+
+### Handler matrix
+
+`ExternalStoreAdapter` is populated as follows. The set differs in two places
+from the one sketched in the parent issue, for reasons given below.
+
+| Member                                         | Used                  | Maps to                                                                                                           |
+| ---------------------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `messages`                                     | yes                   | React state of the converted turn list                                                                            |
+| `convertMessage`                               | yes                   | our `Message` view-model → `ThreadMessageLike`                                                                    |
+| `isRunning`                                    | yes                   | request-in-flight flag, drives the running indicator                                                              |
+| `isLoading`                                    | yes                   | true while a stored conversation is being fetched                                                                 |
+| `onNew`                                        | yes (required)        | append user turn, then `sendChatMessage`                                                                          |
+| `setMessages`                                  | yes                   | lets the runtime rewrite the list — **required for cancel and for branch switching to survive the next snapshot** |
+| `onEdit`                                       | yes                   | truncate to the edited turn, re-run from it                                                                       |
+| `onReload`                                     | yes                   | re-run from a `parentId`, producing another branch                                                                |
+| `onCancel`                                     | yes                   | `AbortController.abort()`, then drop the trailing user turn                                                       |
+| `onDelete`                                     | no                    | not in the spec; no per-message delete affordance                                                                 |
+| `onAddToolResult`                              | **no**                | see below                                                                                                         |
+| `unstable_enableToolInvocations`               | **no** (left `false`) | tools run server-side                                                                                             |
+| `adapters.threadList`                          | **no**                | see "Conversation list" below                                                                                     |
+| `adapters.attachments` / `speech` / `feedback` | no                    | no backend support                                                                                                |
+
+**`onAddToolResult` is deliberately omitted**, against the parent issue's
+assumption. That handler exists so a _client-side_ tool can hand its result back
+to the runtime; the type doc states results flow through it "from `execute()`
+returning, or from `streamCall` resolving". In `mcp-chat` every tool executes
+server-side and its result is already inside the response we convert into
+message parts, so nothing would ever call it. Wiring it would be dead code, and
+enabling the tracker that drives it (`unstable_enableToolInvocations: true`)
+would make the runtime try to dispatch our server-side tool calls a second time.
+
+**`setMessages` is not optional in practice.** Its type doc is explicit: without
+it, "cancelling a run leaves a trailing user message in the thread and the
+composer untouched". Since cancel is a spec'd scenario, `setMessages` is
+required to satisfy it.
+
+### Message conversion
+
+`convertMessage` maps one view-model message to a `ThreadMessageLike`. An
+assistant turn's `content` array is built as: one `{ type: 'text', text }` part
+for the reply, preceded by one `{ type: 'tool-call', toolCallId, toolName, args,
+result, isError }` part per `ToolExecutionResult` — `id` → `toolCallId`, `name` →
+`toolName`, `arguments` → `args`, `result` → `result`. `ToolExecutionResult` has
+no error flag, so `isError` is derived from the result payload; the check lives
+in one helper so it can be replaced if the backend later reports errors
+explicitly.
+
+This is the seam that lets tool rendering meet its spec without any client-side
+tool machinery: the parts are already in the message, and `makeAssistantToolUI`
+renders them.
+
+### Tool call UI: one catch-all `makeAssistantToolUI`
+
+MCP tool names are configuration-driven and unknown at build time, so no
+per-tool component can be registered. A single fallback tool UI renders every
+tool-call part uniformly — name, collapsed arguments and result, copy action,
+error styling — replacing what `ToolCallDetails` does today, in BUI with
+`@remixicon/react` icons.
+
+### Conversation list: own component, not `adapters.threadList`
+
+This settles the question the parent issue left open, and it is the one place
+this design departs from the parent issue's stated target of "thread list pour
+l'historique".
+
+Assistant UI's thread list would cost us the two features the panel has today.
+Its thread status is exactly `regular | archived`; "starred" has no
+representation, and mapping star onto `archived` is wrong — the backend has no
+archive concept, only `DELETE /conversations/:id`, so an "unarchived" thread and
+a deleted one are the same thing. There is no search anywhere in the adapter.
+And the slot plus its switching handlers are all marked as possibly changing
+without notice, which is a poor foundation for a published plugin.
+
+So the panel keeps its own conversation list over the existing
+`useConversations`, which already supplies `conversations`,
+`starredConversations`, `recentConversations`, `searchQuery` / `setSearchQuery`,
+`loadConversation`, `deleteConversation` and `toggleStar` — every spec'd
+behaviour, already implemented and already tested. Selecting a conversation
+calls `loadConversation(id)` and pushes the result into the runtime's `messages`
+state plus the active `conversationId`; "new conversation" clears both.
+
+Trade-off accepted: we forgo Assistant UI's `ThreadListPrimitive` markup and its
+future thread features, and we keep `useConversations`' client-side search, which
+only filters the page the backend returned. Both are contained in the panel.
+
+Migration path if the slot stabilises: `ExternalStoreThreadData.custom` with
+`onUpdateCustom` is where `isStarred` would live, and search would stay a panel
+concern above the adapter either way, since the adapter has no search notion to
+grow into.
+
+Rejected alternatives: thread list with star dropped (loses a working feature to
+adopt an unstable API); star mapped onto `archived` (semantically wrong, and
+`onUnarchive` has no backend counterpart).
+
+### Layout, styling, NFS wiring
+
+`@backstage/ui` for layout and controls, CSS modules with BUI design tokens,
+`@remixicon/react` for icons. Assistant UI primitives are unstyled, so they take
+our class names directly and no vendor stylesheet is imported.
+
+A new `promptRouteRef` joins `rootRouteRef` in `src/routes.ts`; a second
+`PageBlueprint` is added to `src/alpha.tsx` and registered in the plugin's
+`routes` map; the page component is lazy-loaded through `src/wiring.ts` like
+`chatPageContentLoader` is. Both blueprints coexist in the one
+`createFrontendPlugin` call.
+
+### Peer dependency range
+
+`@assistant-ui/react@0.15.16` declares peers `react`/`react-dom` `^18 || ^19`,
+while the plugin declares `^17.0.0 || ^18.0.0`. Keeping React 17 in range would
+publish a package whose peers cannot all be satisfied. The range is narrowed to
+`^18` — the intersection — for `react`, `react-dom` and `@types/react`. Backstage
+1.40 requires React 18 and the workspace resolves `18.3.1`, so this documents
+reality rather than dropping working support. `^18 || ^19` is not adopted:
+nothing else in the workspace is tested against React 19.
+
+## Risks / Trade-offs
+
+- **No token streaming, while the parent issue's acceptance criteria ask for
+  streaming** → Cannot be resolved in this change: the backend answers once.
+  Mitigated by a running indicator and working cancel, so the page never looks
+  frozen. Escalated rather than absorbed silently — the spec states the
+  non-requirement explicitly and the proposal records it as deferred, so adding a
+  streaming endpoint later changes no other requirement.
+- **Assistant UI is pre-1.0 (`0.15.16`)** → Depend only on non-`unstable_`,
+  non-deprecated surface (this is what rules out `adapters.threadList`). Pin an
+  exact-minor range and treat upgrades as reviewed changes.
+- **The dependency tree grows by ~10 transitive packages** → All MIT, verified.
+  `yarn dedupe` is run and `yarn dedupe --check` gated in CI. `zod` and `zustand`
+  arriving in the workspace risks duplicate resolutions; dedupe before `tsc:full`,
+  since duplicate copies of one library surface as spurious type errors.
+- **Two chat UIs to maintain** → Accepted and time-boxed: retiring the old page
+  is a separate decision once the new one has adopter feedback.
+- **Duplicated panel presentation between old and new page** → Accepted: the data
+  layer (`useMcpServers`, `useProviderStatus`, `useConversations`) is shared, only
+  the markup is not, because the two pages target different component libraries.
+- **`isError` for a tool call is inferred, not reported** → Isolated in one
+  helper, so a future backend field replaces one function.
+
+## Migration Plan
+
+Additive and adopter-driven. The new page ships behind its own route and is not
+mounted automatically; adopters add its extension when they want it. Rollback for
+an adopter is removing the mount — the existing page is untouched, so there is no
+data or route migration and nothing to reverse on the backend. The only change
+visible to an adopter who does nothing is the narrowed React peer range.
+
+## Open Questions
+
+- Which path the new route should take (`/mcp-chat/prompt` as a child of the
+  existing path, or a sibling such as `/mcp-chat-prompt`). Both satisfy the
+  spec's "own route" requirement and the choice does not affect the adapter, the
+  panel or the task breakdown.
+- Whether the reduced panel should default to collapsed on narrow viewports. A
+  presentation detail with no spec'd behaviour attached.

--- a/openspec/changes/add-mcp-chat-prompt-page/proposal.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/proposal.md
@@ -32,10 +32,16 @@ them one hook at a time, without disturbing the page adopters run today.
   presentation components.
 - Narrow the plugin's `react`, `react-dom` and `@types/react` peer ranges from
   `^17.0.0 || ^18.0.0` to `^18`, to match what `@assistant-ui/react` declares.
-- **No streaming of response tokens.** The page renders a running indicator
-  while a request is in flight and the assistant message in one shot when it
-  resolves. See "Deferred" below — this is a deliberate scope cut forced by the
-  backend contract, not an oversight.
+- **Add a streaming chat endpoint to the backend**, alongside the existing
+  single-response one, emitting server-sent events for reply fragments, MCP
+  tool-call starts and their results. The existing `POST /chat` stays unchanged so
+  the current page keeps working.
+- Give the provider abstraction an optional incremental-output path, with a
+  fallback that emits a non-streaming provider's whole reply as one fragment, so
+  the endpoint behaves uniformly across all nine provider modules and each one can
+  gain real streaming independently.
+- Render the reply **incrementally** on the new page, with MCP tool invocations
+  appearing as they start and resolving in place when their result arrives.
 
 ### Decisions settled here
 
@@ -56,12 +62,11 @@ migration path if the slot stabilises.
 
 ### Deferred
 
-- **Incremental token streaming.** `POST /chat` answers with a single JSON
-  body (`{ role, content, toolResponses, toolsUsed, conversationId }`) after the
-  provider and every MCP tool call have finished; `McpChatApi.sendChatMessage`
-  returns `Promise<ChatResponse>`. Streaming cannot be delivered from the
-  frontend alone, and adding a server-sent-events endpoint is explicitly outside
-  this change. Tracked as a follow-up against the backend.
+- **Native incremental output for every provider module.** The streaming endpoint
+  and its contract are delivered now, and every provider is reachable through it,
+  but a provider that has not yet implemented incremental output is served by the
+  single-fragment fallback. Bringing each of the nine modules to native streaming
+  is per-provider follow-up work that changes no requirement in this change.
 - **Attachments, speech, dictation and feedback adapters.** No backend support.
 - **Retiring the existing page.** A separate decision once the new page has
   adopter feedback.
@@ -70,35 +75,57 @@ migration path if the slot stabilises.
 
 ### New Capabilities
 
+- `mcp-chat/chat-streaming`: the backend's streaming chat contract — a server-sent
+  event endpoint carrying reply fragments, MCP tool-call starts and results,
+  uniform across providers via a non-streaming fallback, with cancellation,
+  authorization and persistence parity with the existing endpoint.
 - `mcp-chat/prompt-page`: an Assistant UI-based conversation page for the
-  `mcp-chat` plugin — prompt submission, run lifecycle and cancellation, MCP
-  tool-call rendering, provider error handling, message editing and
-  regeneration, and a reduced side panel for MCP server toggles, provider status
-  and conversation selection.
+  `mcp-chat` plugin — prompt submission, incremental reply rendering, run
+  lifecycle and cancellation, MCP tool-call rendering, provider error handling,
+  message editing and regeneration, and a reduced side panel for MCP server
+  toggles, provider status and conversation selection.
 
 ### Modified Capabilities
 
 None. `openspec/specs/` is empty, the existing page has no spec to amend, and
-this change adds a page beside it rather than altering its behaviour.
+this change adds a page beside it rather than altering its behaviour. The existing
+`POST /chat` endpoint is left untouched, so it gains no delta either.
 
 ## Impact
 
 **Package** — `workspaces/mcp-chat/plugins/mcp-chat`
-(`@alithya-oss/backstage-plugin-mcp-chat`), the only package touched.
+(`@alithya-oss/backstage-plugin-mcp-chat`), the frontend package.
 
 - New sources under `src/components/PromptPage`, a new route ref in
   `src/routes.ts`, a second `PageBlueprint` in `src/alpha.tsx`, new exports in
   `src/wiring.ts`.
+- `src/api/McpChatApi.ts`: gains a streaming method that consumes the new
+  endpoint and surfaces its events. `sendChatMessage` and every other existing
+  method keep their current signature and behaviour, so the existing page is
+  unaffected.
+- `src/types.ts`: gains the stream event types and a streaming capability flag on
+  provider status. Existing types are not altered.
 - `package.json`: adds `@assistant-ui/react` and `@remixicon/react`
   dependencies; narrows the `react` / `react-dom` / `@types/react` peer ranges to
   `^18` (adopters still on React 17 lose support — the workspace already
   resolves `18.3.1`, and Backstage 1.40 requires 18, so no supported adopter is
   affected in practice).
-- `src/api/McpChatApi.ts`, `src/types.ts`, `src/components/ChatContainer/**`,
-  `src/components/RightPane/**` and `src/components/ChatPage/**`: unchanged.
+- `src/components/ChatContainer/**`, `src/components/RightPane/**` and
+  `src/components/ChatPage/**`: unchanged.
 
-**Backend** — none. No route, service or database change in
-`mcp-chat-backend`, `mcp-chat-node` or `mcp-chat-common`.
+**Backend** — now in scope, where it previously was not.
+
+- `mcp-chat-backend`: a new streaming route beside `POST /chat`, and a streaming
+  variant of the query-processing path that emits fragments and tool events
+  instead of accumulating them. `POST /chat` and its handler stay as they are.
+- `mcp-chat-node`: `LLMProvider` gains an optional incremental-output method plus
+  a capability flag, with a base implementation that falls back to the existing
+  `sendMessage` and emits one fragment. Because the fallback lives in the base
+  class, the nine provider modules compile unchanged and opt in individually.
+- `mcp-chat-common`: shared event payload types for the stream, and a streaming
+  capability flag on provider status.
+- Native-MCP providers, which take the separate responses-API path, keep working
+  through the same fallback until that path gains streaming of its own.
 
 **Workspace** — `yarn.lock` gains the Assistant UI tree (`@assistant-ui/core`,
 `@assistant-ui/store`, `@assistant-ui/tap`, `assistant-stream`,
@@ -106,6 +133,8 @@ this change adds a page beside it rather than altering its behaviour.
 MIT. Assistant UI Cloud is a paid hosted service and is not used: the runtime
 points at the plugin's own backend.
 
-**Adopters** — additive. The new page must be mounted explicitly; existing
-installations that do not mount it see no behavioural change beyond the peer
-range narrowing.
+**Adopters** — additive, and now spanning more packages. The new page must be
+mounted explicitly, and the new endpoint is additive, so an installation that
+mounts neither sees no behavioural change beyond the peer range narrowing.
+Changesets are needed for the frontend plugin and for each backend package
+touched.

--- a/openspec/changes/add-mcp-chat-prompt-page/proposal.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/proposal.md
@@ -1,0 +1,111 @@
+## Why
+
+The `mcp-chat` frontend plugin renders its conversation UI from hand-written
+primitives: `ChatContainer` owns the message list, the composer, the abort
+controller and the error strings, while `ToolCallDetails` renders tool output as
+Material UI chips and collapses. Every conversational affordance an adopter
+expects — editing a prompt and re-running it, regenerating an answer, branching,
+keyboard-accessible message actions, viewport auto-scroll — has to be built and
+maintained by hand, and today most of them simply do not exist.
+
+`@assistant-ui/react` (MIT, `0.15.16`) supplies those primitives as unstyled,
+Radix-based components driven by a runtime abstraction. Adopting it for a new
+page lets the plugin inherit the conversational mechanics instead of growing
+them one hook at a time, without disturbing the page adopters run today.
+
+## What Changes
+
+- Add a **second, independent page** to the `mcp-chat` plugin, mounted on its own
+  route with its own route ref. The existing `/mcp-chat` page and every component
+  under `src/components/ChatContainer` and `src/components/RightPane` are left
+  untouched. Nothing is removed and nothing is deprecated.
+- Adapt the existing `mcpChatApiRef` transport into an `ExternalStoreAdapter`
+  and provide it through `useExternalStoreRuntime`. No new backend endpoint, no
+  change to `McpChatApi`.
+- Render MCP tool calls with `makeAssistantToolUI` instead of a bespoke
+  `ToolCallDetails`-style component, mapping the backend's `toolResponses`
+  entries onto Assistant UI `tool-call` message parts.
+- Ship a **reduced side panel** on the new page carrying the three concerns
+  Assistant UI has no model for — MCP server enable/disable toggles, read-only
+  provider status, and conversation selection — built on the existing
+  `useMcpServers`, `useProviderStatus` and `useConversations` hooks with new
+  presentation components.
+- Narrow the plugin's `react`, `react-dom` and `@types/react` peer ranges from
+  `^17.0.0 || ^18.0.0` to `^18`, to match what `@assistant-ui/react` declares.
+- **No streaming of response tokens.** The page renders a running indicator
+  while a request is in flight and the assistant message in one shot when it
+  resolves. See "Deferred" below — this is a deliberate scope cut forced by the
+  backend contract, not an oversight.
+
+### Decisions settled here
+
+**Conversation search and pinning are kept, but not on top of Assistant UI's
+thread list.** The question left open by the parent issue offered two options —
+reimplement them over the Assistant UI thread list, or drop them from iteration
+one. Neither is taken. `ExternalStoreThreadListAdapter` cannot express either
+concept (its status model is exactly `regular | archived`, it has no search
+notion) and the whole `adapters.threadList` slot, along with `threadId`,
+`onSwitchToThread` and `onSwitchToNewThread`, is marked
+`@deprecated ... under active development and might change without notice` in
+`0.15.16`. Conversation selection therefore lives in the reduced side panel over
+`useConversations`, which already implements search, star and delete, and feeds
+the runtime through `messages` / `setMessages`. Search and pinning survive at no
+extra cost and the plugin takes on no dependency on an API the vendor says may
+change without notice. `design.md` records the rejected alternative and the
+migration path if the slot stabilises.
+
+### Deferred
+
+- **Incremental token streaming.** `POST /chat` answers with a single JSON
+  body (`{ role, content, toolResponses, toolsUsed, conversationId }`) after the
+  provider and every MCP tool call have finished; `McpChatApi.sendChatMessage`
+  returns `Promise<ChatResponse>`. Streaming cannot be delivered from the
+  frontend alone, and adding a server-sent-events endpoint is explicitly outside
+  this change. Tracked as a follow-up against the backend.
+- **Attachments, speech, dictation and feedback adapters.** No backend support.
+- **Retiring the existing page.** A separate decision once the new page has
+  adopter feedback.
+
+## Capabilities
+
+### New Capabilities
+
+- `mcp-chat/prompt-page`: an Assistant UI-based conversation page for the
+  `mcp-chat` plugin — prompt submission, run lifecycle and cancellation, MCP
+  tool-call rendering, provider error handling, message editing and
+  regeneration, and a reduced side panel for MCP server toggles, provider status
+  and conversation selection.
+
+### Modified Capabilities
+
+None. `openspec/specs/` is empty, the existing page has no spec to amend, and
+this change adds a page beside it rather than altering its behaviour.
+
+## Impact
+
+**Package** — `workspaces/mcp-chat/plugins/mcp-chat`
+(`@alithya-oss/backstage-plugin-mcp-chat`), the only package touched.
+
+- New sources under `src/components/PromptPage`, a new route ref in
+  `src/routes.ts`, a second `PageBlueprint` in `src/alpha.tsx`, new exports in
+  `src/wiring.ts`.
+- `package.json`: adds `@assistant-ui/react` and `@remixicon/react`
+  dependencies; narrows the `react` / `react-dom` / `@types/react` peer ranges to
+  `^18` (adopters still on React 17 lose support — the workspace already
+  resolves `18.3.1`, and Backstage 1.40 requires 18, so no supported adopter is
+  affected in practice).
+- `src/api/McpChatApi.ts`, `src/types.ts`, `src/components/ChatContainer/**`,
+  `src/components/RightPane/**` and `src/components/ChatPage/**`: unchanged.
+
+**Backend** — none. No route, service or database change in
+`mcp-chat-backend`, `mcp-chat-node` or `mcp-chat-common`.
+
+**Workspace** — `yarn.lock` gains the Assistant UI tree (`@assistant-ui/core`,
+`@assistant-ui/store`, `@assistant-ui/tap`, `assistant-stream`,
+`assistant-cloud`, `radix-ui`, `zustand`, `zod`, `react-textarea-autosize`), all
+MIT. Assistant UI Cloud is a paid hosted service and is not used: the runtime
+points at the plugin's own backend.
+
+**Adopters** — additive. The new page must be mounted explicitly; existing
+installations that do not mount it see no behavioural change beyond the peer
+range narrowing.

--- a/openspec/changes/add-mcp-chat-prompt-page/specs/mcp-chat/chat-streaming/spec.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/specs/mcp-chat/chat-streaming/spec.md
@@ -1,0 +1,150 @@
+## Purpose
+
+Defines the streaming chat contract the `mcp-chat` backend exposes so a client can
+render an assistant reply as it is produced, observe MCP tool invocations as they
+happen, and cancel work in flight — without changing the existing single-response
+chat endpoint.
+
+## ADDED Requirements
+
+### Requirement: Streaming chat endpoint
+
+The backend SHALL expose a streaming chat endpoint accepting the same request
+payload as the existing single-response chat endpoint — the prior conversation,
+the set of enabled MCP server ids, and an optional conversation id — and SHALL
+respond with a server-sent event stream.
+
+The existing single-response endpoint SHALL remain available and unchanged, so a
+client that does not stream keeps working.
+
+#### Scenario: A streaming request is accepted
+
+- **WHEN** a client posts a valid conversation to the streaming endpoint
+- **THEN** the response is an event stream that stays open until the run reaches a
+  terminal event
+
+#### Scenario: The request is invalid
+
+- **WHEN** a client posts a payload the single-response endpoint would reject
+  (malformed messages, a non-array set of enabled servers, or a malformed
+  conversation id)
+- **THEN** the streaming endpoint rejects it the same way, before opening a stream
+
+#### Scenario: The non-streaming endpoint is unaffected
+
+- **WHEN** a client posts to the existing single-response chat endpoint
+- **THEN** it behaves exactly as before this change, returning one complete reply
+
+### Requirement: Stream event sequence
+
+The stream SHALL carry named events, each with a JSON payload:
+
+- a text event carrying an incremental fragment of the assistant reply;
+- a tool-call event carrying the invocation's id, tool name, arguments and the
+  MCP server that will run it;
+- a tool-result event carrying the matching invocation id, its result, and
+  whether it failed;
+- exactly one terminal event, either completion — carrying the persisted
+  conversation id when the conversation was stored, and the names of the tools
+  used — or failure, carrying a human-readable message.
+
+Text fragments SHALL arrive in reply order, so concatenating them in arrival
+order reproduces the complete reply. A tool-result event SHALL NOT precede the
+tool-call event bearing the same id. Exactly one terminal event SHALL be sent, and
+no event SHALL follow it.
+
+#### Scenario: A reply is streamed without tools
+
+- **WHEN** the provider produces a reply and no tool is invoked
+- **THEN** the stream carries the reply as one or more text events in order,
+  followed by a completion event, and concatenating the fragments yields the
+  whole reply
+
+#### Scenario: A tool is invoked mid-run
+
+- **WHEN** the provider requests an MCP tool during the run
+- **THEN** a tool-call event is emitted with the invocation's id, name, arguments
+  and server, its outcome follows as a tool-result event bearing the same id, and
+  any further reply text follows as text events
+
+#### Scenario: A tool invocation fails
+
+- **WHEN** an invoked MCP tool returns an error or exceeds its timeout
+- **THEN** a tool-result event marks that invocation as failed and the run
+  continues to a terminal event rather than aborting the stream
+
+#### Scenario: The provider fails mid-stream
+
+- **WHEN** the provider fails after some text has already been sent
+- **THEN** a failure event terminates the stream, and the fragments already sent
+  are not retracted
+
+### Requirement: Providers without native streaming
+
+Streaming SHALL be available for every configured provider. A provider that
+cannot produce incremental output SHALL be served by emitting its complete reply
+as a single text event followed by the terminal event, so the client observes one
+event shape regardless of provider.
+
+The backend SHALL report, as part of provider status, whether a provider streams
+incrementally, so a client can tell genuine streaming from the single-fragment
+fallback.
+
+#### Scenario: A provider streams natively
+
+- **WHEN** the active provider supports incremental output
+- **THEN** the reply arrives as several text events as the provider produces it
+
+#### Scenario: A provider does not stream natively
+
+- **WHEN** the active provider cannot produce incremental output
+- **THEN** the endpoint still answers with a valid stream whose reply arrives as a
+  single text event, followed by the terminal event
+
+#### Scenario: Streaming capability is reported
+
+- **WHEN** a client reads provider status
+- **THEN** it can determine whether the active provider streams incrementally
+
+### Requirement: Cancellation and disconnection
+
+When a client disconnects or cancels, the backend SHALL stop the run: it SHALL
+abandon the provider request and SHALL NOT start further MCP tool invocations for
+that run. A cancelled run SHALL NOT be persisted as a completed conversation.
+
+#### Scenario: The client disconnects mid-stream
+
+- **WHEN** a client closes the connection while the provider is still producing
+- **THEN** the backend abandons the provider request, starts no further tool
+  invocation for that run, and releases the stream
+
+#### Scenario: A cancelled run is not stored
+
+- **WHEN** a run is cancelled before its terminal event
+- **THEN** no conversation is created or updated for that run
+
+### Requirement: Authorization and persistence parity
+
+The streaming endpoint SHALL apply the same identity and authorization rules as
+the single-response endpoint, and SHALL persist a completed conversation on the
+same terms — stored for an authenticated non-guest user, skipped for a guest,
+with a title generated for a newly created conversation.
+
+A failure to persist SHALL NOT fail the run: the stream SHALL still reach its
+completion event.
+
+#### Scenario: An authenticated user streams a reply
+
+- **WHEN** an authenticated non-guest user completes a streamed run
+- **THEN** the conversation is stored and the completion event carries its id
+
+#### Scenario: A guest user streams a reply
+
+- **WHEN** a guest user completes a streamed run
+- **THEN** the reply streams normally, nothing is stored, and the completion event
+  carries no conversation id
+
+#### Scenario: Persistence fails
+
+- **WHEN** storing the conversation fails after the reply has been produced
+- **THEN** the stream still reaches its completion event and the reply is not lost

--- a/openspec/changes/add-mcp-chat-prompt-page/specs/mcp-chat/prompt-page/spec.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/specs/mcp-chat/prompt-page/spec.md
@@ -1,0 +1,254 @@
+## Purpose
+
+Defines the conversation page the `mcp-chat` plugin offers alongside its
+existing chat page: how a user submits a prompt, how the run reports progress
+and completes, how MCP tool calls and provider failures surface, how a user
+revises or regenerates a turn, and what the page's side panel controls.
+
+## ADDED Requirements
+
+### Requirement: Page availability alongside the existing chat page
+
+The plugin SHALL expose the conversation page on its own route, distinct from
+the route of the pre-existing chat page. Both pages SHALL remain independently
+reachable and functional in the same application, and the new page SHALL be
+mountable without altering the existing page's route, behaviour or appearance.
+
+#### Scenario: Both pages are reachable
+
+- **WHEN** an application mounts both the pre-existing chat page and the new
+  conversation page
+- **THEN** each is reachable at its own path, and using one leaves the other's
+  behaviour unchanged
+
+#### Scenario: The new page is not mounted
+
+- **WHEN** an application upgrades the plugin but mounts only the pre-existing
+  chat page
+- **THEN** the application behaves exactly as before the upgrade
+
+### Requirement: Prompt submission
+
+The page SHALL provide a composer that accepts multi-line text. Submitting a
+non-empty prompt SHALL append it to the conversation as a user turn, clear the
+composer, and start a run against the chat provider carrying the full prior
+conversation and the set of currently enabled MCP servers. A blank or
+whitespace-only prompt SHALL NOT start a run.
+
+#### Scenario: A prompt is submitted
+
+- **WHEN** the user types `list my components` and submits
+- **THEN** `list my components` appears as the latest user turn, the composer is
+  emptied, and a run starts carrying that prompt together with the preceding
+  turns
+
+#### Scenario: An empty prompt is rejected
+
+- **WHEN** the user submits with the composer empty or containing only
+  whitespace
+- **THEN** no turn is appended and no run starts
+
+#### Scenario: A prompt is submitted while a run is active
+
+- **WHEN** a run is already in flight and the user submits another prompt
+- **THEN** the page SHALL NOT interleave two runs against the same conversation
+
+### Requirement: Run lifecycle and completion
+
+While a run is in flight the page SHALL indicate that the assistant is working,
+and SHALL keep that indication visible until the run completes, fails or is
+cancelled. On success the assistant turn SHALL be appended with the provider's
+reply rendered as formatted text.
+
+The reply SHALL be revealed as a single completed turn. Incremental
+token-by-token rendering is explicitly NOT required by this capability, because
+the chat endpoint answers once, after the provider and all tool calls have
+finished. A future change MAY introduce incremental rendering; doing so SHALL
+NOT change any other requirement in this capability.
+
+#### Scenario: A run is in progress
+
+- **WHEN** a prompt has been submitted and the provider has not yet answered
+- **THEN** the page shows a running indication and offers a way to cancel
+
+#### Scenario: A run completes successfully
+
+- **WHEN** the provider returns a reply
+- **THEN** the running indication clears and the reply is appended as an
+  assistant turn with markdown rendered as formatted text
+
+#### Scenario: A run is cancelled
+
+- **WHEN** the user cancels a run that is in flight
+- **THEN** the in-flight request is aborted, the running indication clears, no
+  assistant turn is appended for the abandoned run, and the conversation is left
+  in a state where the user can submit again
+
+### Requirement: MCP tool call rendering
+
+When a run reports that MCP tools were invoked, the page SHALL render each
+invocation as part of the assistant turn, showing the tool's name and, on
+demand, the arguments it received and the result it returned. Results SHALL be
+collapsed by default, individually expandable, and copyable. A tool invocation
+that failed SHALL be visually distinguishable from one that succeeded.
+
+#### Scenario: A single tool is invoked
+
+- **WHEN** a run reports one tool invocation with its arguments and result
+- **THEN** the assistant turn shows that tool's name in a collapsed state, and
+  expanding it reveals the arguments and the result
+
+#### Scenario: Several tools are invoked in one turn
+
+- **WHEN** a run reports more than one tool invocation
+- **THEN** every invocation is listed on the assistant turn and each expands
+  independently of the others
+
+#### Scenario: A tool result is copied
+
+- **WHEN** the user copies an expanded tool result
+- **THEN** the result is placed on the clipboard and the page acknowledges the
+  copy
+
+#### Scenario: A tool invocation fails
+
+- **WHEN** a run reports a tool invocation that returned an error
+- **THEN** that invocation is shown as failed and its error detail is available
+  on expansion
+
+#### Scenario: No tool is invoked
+
+- **WHEN** a run reports no tool invocations
+- **THEN** the assistant turn shows the reply with no tool-call section
+
+### Requirement: Provider and transport error handling
+
+A run that fails SHALL surface the failure to the user on the page, distinguish
+a failure from a successful reply, leave the user's prompt recoverable rather
+than silently discarded, and offer a retry. A failure SHALL NOT be presented as
+assistant content, and SHALL NOT leave the page stuck in a running state.
+
+#### Scenario: The chat provider returns an error
+
+- **WHEN** a run fails because the provider rejects the request
+- **THEN** the page shows an error distinct from assistant content, the running
+  indication clears, and a retry is offered
+
+#### Scenario: The backend is unreachable
+
+- **WHEN** a run fails because the plugin's backend cannot be reached
+- **THEN** the page shows an error saying the chat service is unavailable, and a
+  retry is offered
+
+#### Scenario: A retry succeeds after a failure
+
+- **WHEN** the user retries a run that previously failed and the provider answers
+- **THEN** the error is replaced by the assistant turn and the conversation
+  continues from that turn
+
+### Requirement: Revising and regenerating turns
+
+The page SHALL let the user edit an earlier user turn and re-run from it, and
+regenerate the answer to the latest user turn. Both SHALL start a new run from
+the edited or repeated prompt. Where a turn has more than one answer, the page
+SHALL let the user move between them and SHALL indicate which one is shown.
+
+#### Scenario: A user turn is edited and re-run
+
+- **WHEN** the user edits an earlier user turn and confirms
+- **THEN** a run starts from the edited text and its answer becomes the shown
+  answer for that turn
+
+#### Scenario: An answer is regenerated
+
+- **WHEN** the user regenerates the answer to the latest user turn
+- **THEN** a run starts from that same prompt and produces another answer for it
+
+#### Scenario: Moving between alternative answers
+
+- **WHEN** a user turn has more than one answer
+- **THEN** the page indicates the position among them and lets the user move to
+  another, and the conversation below reflects the selected one
+
+### Requirement: Selecting an existing conversation
+
+The page's side panel SHALL list the signed-in user's stored conversations, most
+recently updated first, identified by title where one exists. Selecting a
+conversation SHALL replace the page's conversation with its stored turns and
+SHALL direct subsequent runs at that conversation. The panel SHALL offer
+starting a fresh, empty conversation.
+
+Search over the list and pinning a conversation SHALL both remain available: the
+user SHALL be able to narrow the list by text matched against conversation
+titles and user turns, and SHALL be able to pin and unpin a conversation, with
+pinned conversations grouped ahead of the rest.
+
+A user with no stored conversations, and a user whose identity cannot own stored
+conversations, SHALL both still be able to hold a conversation on the page; only
+the stored list is unavailable to them.
+
+#### Scenario: An existing conversation is selected
+
+- **WHEN** the user selects a stored conversation from the panel
+- **THEN** its stored turns replace the page's conversation in their stored
+  order, and the next prompt continues that same stored conversation rather than
+  starting a new one
+
+#### Scenario: A fresh conversation is started
+
+- **WHEN** the user starts a new conversation from the panel
+- **THEN** the page's conversation is emptied and the next prompt creates a new
+  stored conversation
+
+#### Scenario: The list is searched
+
+- **WHEN** the user enters search text
+- **THEN** the list narrows to conversations whose title or user turns match the
+  text, case-insensitively
+
+#### Scenario: A conversation is pinned
+
+- **WHEN** the user pins a conversation
+- **THEN** it is grouped ahead of the unpinned ones and stays pinned across a
+  reload of the page
+
+#### Scenario: A conversation is deleted
+
+- **WHEN** the user deletes a conversation
+- **THEN** it leaves the list immediately, and if the deletion fails it returns
+  to the list and the user is told
+
+#### Scenario: The user has no stored conversations
+
+- **WHEN** the signed-in user has no stored conversations, or cannot own stored
+  conversations
+- **THEN** the panel reports an empty list without an error, and the composer
+  still accepts a prompt
+
+### Requirement: MCP server selection and provider status
+
+The side panel SHALL list the configured MCP servers and let the user enable or
+disable each one. Only enabled servers' tools SHALL be offered to the provider
+on subsequent runs. The panel SHALL also show, read-only, whether the chat
+provider is reachable and which model it reports.
+
+Failure to load the server list or the provider status SHALL NOT prevent the
+user from holding a conversation.
+
+#### Scenario: A server is disabled
+
+- **WHEN** the user disables an MCP server and then submits a prompt
+- **THEN** that server's tools are not offered to the provider for that run,
+  while the enabled servers' tools still are
+
+#### Scenario: Provider status is shown
+
+- **WHEN** the provider status has loaded
+- **THEN** the panel shows the connection state and the reported model name, and
+  offers no control to change them
+
+#### Scenario: Provider status cannot be loaded
+
+- **WHEN** the provider status request fails
+- **THEN** the panel reports the status as unavailable and the composer still
+  accepts a prompt

--- a/openspec/changes/add-mcp-chat-prompt-page/specs/mcp-chat/prompt-page/spec.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/specs/mcp-chat/prompt-page/spec.md
@@ -53,36 +53,56 @@ whitespace-only prompt SHALL NOT start a run.
 - **WHEN** a run is already in flight and the user submits another prompt
 - **THEN** the page SHALL NOT interleave two runs against the same conversation
 
-### Requirement: Run lifecycle and completion
+### Requirement: Run lifecycle and streamed completion
 
 While a run is in flight the page SHALL indicate that the assistant is working,
 and SHALL keep that indication visible until the run completes, fails or is
-cancelled. On success the assistant turn SHALL be appended with the provider's
-reply rendered as formatted text.
+cancelled.
 
-The reply SHALL be revealed as a single completed turn. Incremental
-token-by-token rendering is explicitly NOT required by this capability, because
-the chat endpoint answers once, after the provider and all tool calls have
-finished. A future change MAY introduce incremental rendering; doing so SHALL
-NOT change any other requirement in this capability.
+The assistant reply SHALL be rendered incrementally as it arrives, so text
+becomes readable before the run finishes. The turn SHALL be marked as still
+running while fragments are arriving and as complete once the run terminates.
+Fragments SHALL be appended in arrival order so the rendered text always matches
+what the provider has produced so far.
+
+Where the active provider cannot produce incremental output, the reply SHALL
+still render correctly — arriving as a single fragment — without a separate code
+path on the page.
 
 #### Scenario: A run is in progress
 
-- **WHEN** a prompt has been submitted and the provider has not yet answered
+- **WHEN** a prompt has been submitted and no reply fragment has arrived yet
 - **THEN** the page shows a running indication and offers a way to cancel
+
+#### Scenario: A reply renders incrementally
+
+- **WHEN** reply fragments arrive one after another
+- **THEN** the assistant turn grows as each fragment arrives, remains marked as
+  running, and its text at any moment equals the fragments received so far
 
 #### Scenario: A run completes successfully
 
-- **WHEN** the provider returns a reply
-- **THEN** the running indication clears and the reply is appended as an
-  assistant turn with markdown rendered as formatted text
+- **WHEN** the run reaches its terminal completion
+- **THEN** the running indication clears, the assistant turn is marked complete,
+  and its markdown is rendered as formatted text
+
+#### Scenario: A non-streaming provider is used
+
+- **WHEN** the active provider delivers its whole reply as a single fragment
+- **THEN** the assistant turn renders that reply and completes normally
 
 #### Scenario: A run is cancelled
 
 - **WHEN** the user cancels a run that is in flight
-- **THEN** the in-flight request is aborted, the running indication clears, no
-  assistant turn is appended for the abandoned run, and the conversation is left
-  in a state where the user can submit again
+- **THEN** the request is abandoned, the running indication clears, any partial
+  assistant turn is removed rather than left marked as running, and the
+  conversation is left in a state where the user can submit again
+
+#### Scenario: A run fails after partial output
+
+- **WHEN** the run fails once some reply text has already been rendered
+- **THEN** the partial text is kept and marked as interrupted rather than silently
+  presented as a complete answer, and a retry is offered
 
 ### Requirement: MCP tool call rendering
 
@@ -91,6 +111,23 @@ invocation as part of the assistant turn, showing the tool's name and, on
 demand, the arguments it received and the result it returned. Results SHALL be
 collapsed by default, individually expandable, and copyable. A tool invocation
 that failed SHALL be visually distinguishable from one that succeeded.
+
+An invocation SHALL appear as soon as the run reports it starting, before its
+result is known, and SHALL show that it is still running until its outcome
+arrives.
+
+#### Scenario: An invocation is shown before its result arrives
+
+- **WHEN** the run reports a tool invocation starting and its result has not yet
+  arrived
+- **THEN** the invocation appears on the assistant turn with its name and
+  arguments, marked as still running
+
+#### Scenario: A running invocation receives its result
+
+- **WHEN** the outcome of an invocation already shown as running arrives
+- **THEN** that same invocation stops being marked as running and exposes its
+  result, without appearing a second time
 
 #### Scenario: A single tool is invoked
 

--- a/openspec/changes/add-mcp-chat-prompt-page/tasks.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/tasks.md
@@ -1,0 +1,171 @@
+Requirement references are to `specs/mcp-chat/prompt-page/spec.md`. All commands
+run from `workspaces/mcp-chat` unless stated otherwise.
+
+## 1. Dependencies, route and page wiring
+
+Covers _Page availability alongside the existing chat page_.
+
+- [ ] 1.1 Add `@assistant-ui/react@0.15.16` and `@remixicon/react` to
+      `plugins/mcp-chat/package.json` dependencies, and narrow the `react`,
+      `react-dom` and `@types/react` peer ranges from `^17.0.0 || ^18.0.0` to
+      `^18`. Verify with `yarn install` reporting no unmet peer warning for
+      `@assistant-ui/react`.
+- [ ] 1.2 Run `yarn dedupe` and commit the resulting `yarn.lock`. Verify
+      `yarn dedupe --check` exits zero — this is what CI gates on, and it must
+      pass before any `tsc` result is trusted.
+- [ ] 1.3 Add `promptRouteRef` to `plugins/mcp-chat/src/routes.ts` and export it
+      from `src/wiring.ts` alongside a lazy loader for the new page, following the
+      existing `chatPageContentLoader` pattern. Verify `yarn tsc:full` passes.
+- [ ] 1.4 Add a second `PageBlueprint` to `plugins/mcp-chat/src/alpha.tsx` bound
+      to `promptRouteRef`, register it in the plugin's `extensions` and `routes`,
+      and leave the existing `mcpChatPage` untouched. Verify by extending
+      `src/alpha.test.tsx` so it asserts both pages render at their own paths —
+      this covers the scenarios _Both pages are reachable_ and _The new page is
+      not mounted_.
+
+## 2. External store adapter and message conversion
+
+Covers _Prompt submission_, _Run lifecycle and completion_, _Provider and
+transport error handling_ (state layer).
+
+- [ ] 2.1 Add a `usePromptThread` hook holding the turn list, the active
+      `conversationId`, the in-flight `AbortController` and the running flag.
+      Verify with unit tests asserting a submitted prompt is appended and a blank
+      prompt is not — scenarios _A prompt is submitted_ and _An empty prompt is
+      rejected_.
+- [ ] 2.2 Implement `convertMessage`, mapping a view-model turn to
+      `ThreadMessageLike`: the reply as a `text` part, and each
+      `ToolExecutionResult` as a `tool-call` part (`id` → `toolCallId`, `name` →
+      `toolName`, `arguments` → `args`, `result` → `result`), with `isError`
+      derived in a single named helper as `design.md` requires. Verify with unit
+      tests over a reply with zero, one and several tool results.
+- [ ] 2.3 Implement `onNew`: append the user turn, call
+      `mcpChatApi.sendChatMessage` with the full prior conversation, the enabled
+      server ids, the abort signal and the active `conversationId`, then append
+      the assistant turn and record the returned `conversationId`. Verify with a
+      test asserting the enabled-server ids reach the API — scenario _A prompt is
+      submitted_.
+- [ ] 2.4 Implement `onCancel` — abort the in-flight request, clear the running
+      flag, and hand the trimmed list back through `setMessages` so the removal
+      survives the next snapshot. Verify with a test asserting no assistant turn
+      is appended and no trailing user turn is left — scenario _A run is
+      cancelled_.
+- [ ] 2.5 Guard against concurrent runs so a submit during an active run does not
+      interleave two runs. Verify with a test — scenario _A prompt is submitted
+      while a run is active_.
+- [ ] 2.6 Map failures to error state rather than assistant content, keeping the
+      prompt recoverable and distinguishing an unreachable backend from a
+      provider rejection. Verify with tests over both failure shapes and a
+      successful retry — scenarios _The chat provider returns an error_, _The
+      backend is unreachable_, _A retry succeeds after a failure_.
+- [ ] 2.7 Assemble the `ExternalStoreAdapter` and pass it to
+      `useExternalStoreRuntime` with exactly the handler set `design.md` fixes —
+      `messages`, `convertMessage`, `isRunning`, `isLoading`, `onNew`,
+      `setMessages`, `onEdit`, `onReload`, `onCancel` — leaving
+      `unstable_enableToolInvocations` at its `false` default and omitting
+      `onAddToolResult` and `adapters.threadList`. Verify `yarn tsc:full` passes
+      with no `unstable_` or deprecated member referenced.
+
+## 3. Thread surface
+
+Covers _Prompt submission_, _Run lifecycle and completion_, _Provider and
+transport error handling_ (presentation).
+
+- [ ] 3.1 Build the composer from `ComposerPrimitive` with multi-line input,
+      submit-on-Enter and newline-on-Shift-Enter, styled with a CSS module over
+      BUI tokens. Verify with a test driving `screen` queries and `findBy*` —
+      scenario _A prompt is submitted_.
+- [ ] 3.2 Build the message list and viewport from `ThreadPrimitive` and
+      `MessagePrimitive`, rendering assistant text as markdown. Verify with a test
+      asserting a completed reply renders as formatted text — scenario _A run
+      completes successfully_.
+- [ ] 3.3 Render the running indicator and the cancel control from the runtime's
+      running state. Verify with a test asserting both appear while a run is in
+      flight and clear afterwards — scenario _A run is in progress_.
+- [ ] 3.4 Render run failures as an error distinct from assistant content, with a
+      retry control. Verify with a test — scenarios _The chat provider returns an
+      error_ and _The backend is unreachable_.
+- [ ] 3.5 Confirm no file added under `src/components/PromptPage` imports
+      `@backstage/core-components`, `@mui/material` or `@mui/icons-material`.
+      Verify with `grep` over the new directory and with `yarn lint --fix`
+      reporting clean.
+
+## 4. MCP tool call rendering
+
+Covers _MCP tool call rendering_.
+
+- [ ] 4.1 Register one catch-all tool UI via `makeAssistantToolUI` rendering a
+      tool-call part's name collapsed by default, expandable to its arguments and
+      result, in BUI with `@remixicon/react` icons. Verify with tests over one and
+      several invocations, asserting independent expansion — scenarios _A single
+      tool is invoked_ and _Several tools are invoked in one turn_.
+- [ ] 4.2 Add the copy affordance for an expanded result, with acknowledgement.
+      Verify with a test asserting the clipboard write and the acknowledgement —
+      scenario _A tool result is copied_.
+- [ ] 4.3 Style a failed invocation distinctly and expose its error detail on
+      expansion. Verify with a test — scenario _A tool invocation fails_.
+- [ ] 4.4 Verify a reply with no tool results renders no tool-call section, with a
+      test — scenario _No tool is invoked_.
+
+## 5. Revising and regenerating
+
+Covers _Revising and regenerating turns_.
+
+- [ ] 5.1 Implement `onEdit` — truncate the list to the edited user turn and
+      re-run from its new text — and surface it through the message action bar and
+      edit composer primitives. Verify with a test — scenario _A user turn is
+      edited and re-run_.
+- [ ] 5.2 Implement `onReload` for the latest user turn and surface a regenerate
+      action. Verify with a test asserting a second answer is produced for the
+      same prompt — scenario _An answer is regenerated_.
+- [ ] 5.3 Render `BranchPickerPrimitive` so a turn with several answers shows its
+      position and allows moving between them, keeping `setMessages` wired so a
+      switch survives the next snapshot. Verify with a test — scenario _Moving
+      between alternative answers_.
+
+## 6. Reduced side panel
+
+Covers _MCP server selection and provider status_ and _Selecting an existing
+conversation_.
+
+- [ ] 6.1 Build the MCP server toggle list on `useMcpServers`, feeding the enabled
+      ids into the adapter's run parameters, without reusing the Material UI
+      `ActiveMcpServers` view. Verify with a test asserting a disabled server's id
+      is absent from the next request — scenario _A server is disabled_.
+- [ ] 6.2 Build the read-only provider status block on `useProviderStatus`,
+      showing connection state and reported model name with no control to change
+      them, and reporting unavailability without blocking the composer. Verify
+      with tests — scenarios _Provider status is shown_ and _Provider status
+      cannot be loaded_.
+- [ ] 6.3 Build the conversation list on `useConversations`, ordered most recently
+      updated first, with pinned conversations grouped ahead of the rest. Selecting
+      one calls `loadConversation` and pushes its turns and id into the thread
+      state; "new conversation" clears both. Verify with tests — scenarios _An
+      existing conversation is selected_ and _A fresh conversation is started_.
+- [ ] 6.4 Wire the search field to `useConversations`' `searchQuery`. Verify with a
+      test asserting case-insensitive narrowing over titles and user turns —
+      scenario _The list is searched_.
+- [ ] 6.5 Wire pin and delete to `toggleStar` and `deleteConversation`, including
+      the rollback-and-inform path on a failed delete. Verify with tests —
+      scenarios _A conversation is pinned_ and _A conversation is deleted_.
+- [ ] 6.6 Handle the empty and non-owning-identity cases so the panel reports an
+      empty list without an error and the composer still accepts a prompt. Verify
+      with a test — scenario _The user has no stored conversations_.
+
+## 7. Workspace verification and release artifacts
+
+- [ ] 7.1 Re-run `yarn dedupe`, then `CI=true yarn test` and `yarn tsc:full`, in
+      that order, and confirm all three pass. Order matters: dedupe rewrites
+      resolved versions, so earlier test and type results do not carry over.
+- [ ] 7.2 Run `yarn lint --fix` and `yarn prettier --write` over the changed
+      paths, and confirm every new `.ts`/`.tsx` file carries the Apache 2.0
+      header with the current year, without touching the year on existing files.
+- [ ] 7.3 Run `yarn build:api-reports` and commit the updated report, since
+      `src/wiring.ts` and `src/alpha.tsx` gain public exports.
+- [ ] 7.4 Add a changeset for `@alithya-oss/backstage-plugin-mcp-chat` describing
+      the new page for adopters and calling out the narrowed React peer range as a
+      breaking change with its migration note.
+- [ ] 7.5 Confirm the diff touches no backend package and none of
+      `src/api/McpChatApi.ts`, `src/types.ts`, `src/components/ChatContainer/**`,
+      `src/components/RightPane/**` or `src/components/ChatPage/**`. Verify with
+      `git diff --stat`.

--- a/openspec/changes/add-mcp-chat-prompt-page/tasks.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/tasks.md
@@ -1,64 +1,126 @@
-Requirement references are to `specs/mcp-chat/prompt-page/spec.md`. All commands
-run from `workspaces/mcp-chat` unless stated otherwise.
+Requirement references are to `specs/mcp-chat/prompt-page/spec.md` and
+`specs/mcp-chat/chat-streaming/spec.md`. All commands run from
+`workspaces/mcp-chat` unless stated otherwise.
 
-## 1. Dependencies, route and page wiring
+Groups 1 and 2 are backend work and gate the frontend streaming groups: build the
+endpoint before the page that consumes it.
+
+## 1. Provider streaming seam
+
+Covers _Providers without native streaming_.
+
+- [ ] 1.1 Add shared stream event payload types to `plugins/mcp-chat-common`
+      (text fragment, tool-call, tool-result, terminal completion, terminal
+      failure) plus a streaming capability flag on provider status, so backend and
+      frontend cannot drift. Verify with `yarn tsc:full`.
+- [ ] 1.2 Add a **concrete** `streamMessage` to the `LLMProvider` base class in
+      `plugins/mcp-chat-node`, defaulting to awaiting the existing `sendMessage`
+      and emitting the whole reply as one fragment, plus `supportsStreaming()`
+      returning `false`. Do **not** make either abstract. Verify that all nine
+      `mcp-chat-backend-module-*` packages still typecheck untouched with
+      `yarn tsc:full` — that is the whole point of the default implementation.
+- [ ] 1.3 Surface `supportsStreaming()` on the provider status payload. Verify with
+      a test — scenario _Streaming capability is reported_.
+- [ ] 1.4 Add tests proving the fallback path yields exactly one fragment then the
+      terminal event — scenario _A provider does not stream natively_.
+
+## 2. Streaming chat endpoint
+
+Covers _Streaming chat endpoint_, _Stream event sequence_, _Cancellation and
+disconnection_, _Authorization and persistence parity_.
+
+- [ ] 2.1 Factor the parts of `QueryProcessor.processQuery` both paths need —
+      system-prompt injection and tool filtering by enabled server id — into
+      helpers, so the streaming variant reuses them instead of copying. Verify
+      existing tests still pass unchanged.
+- [ ] 2.2 Add a streaming query path emitting a text event per provider fragment,
+      a tool-call event before each MCP invocation and a tool-result event after
+      it, correlated by invocation id, then exactly one terminal event. Verify with
+      tests — scenarios _A reply is streamed without tools_, _A tool is invoked
+      mid-run_, _A tool invocation fails_.
+- [ ] 2.3 Add the `POST /chat/stream` route emitting `text/event-stream` with
+      no-buffering headers, validating the body exactly as `POST /chat` does before
+      opening the stream. Verify with tests — scenarios _A streaming request is
+      accepted_ and _The request is invalid_.
+- [ ] 2.4 Tie an `AbortController` to client disconnect: abandon the provider
+      request, start no further tool invocation, and persist nothing for the
+      cancelled run. Verify with tests — scenarios _The client disconnects
+      mid-stream_ and _A cancelled run is not stored_.
+- [ ] 2.5 Apply the same credentials and persistence rules as `POST /chat`,
+      including guest skipping and title generation for a new conversation, and
+      keep a persistence failure from failing the run. Verify with tests —
+      scenarios _An authenticated user streams a reply_, _A guest user streams a
+      reply_, _Persistence fails_.
+- [ ] 2.6 Confirm `POST /chat` is untouched and still passes its existing tests —
+      scenario _The non-streaming endpoint is unaffected_. Verify with
+      `git diff` on `chatRoutes.ts` showing only additive changes.
+- [ ] 2.7 Add a changeset for each backend package touched
+      (`mcp-chat-backend`, `mcp-chat-node`, `mcp-chat-common`) describing the new
+      endpoint and the provider seam for adopters.
+
+## 3. Dependencies, route and page wiring
 
 Covers _Page availability alongside the existing chat page_.
 
-- [ ] 1.1 Add `@assistant-ui/react@0.15.16` and `@remixicon/react` to
+- [ ] 3.1 Add `@assistant-ui/react@0.15.16` and `@remixicon/react` to
       `plugins/mcp-chat/package.json` dependencies, and narrow the `react`,
       `react-dom` and `@types/react` peer ranges from `^17.0.0 || ^18.0.0` to
       `^18`. Verify with `yarn install` reporting no unmet peer warning for
       `@assistant-ui/react`.
-- [ ] 1.2 Run `yarn dedupe` and commit the resulting `yarn.lock`. Verify
+- [ ] 3.2 Run `yarn dedupe` and commit the resulting `yarn.lock`. Verify
       `yarn dedupe --check` exits zero — this is what CI gates on, and it must
       pass before any `tsc` result is trusted.
-- [ ] 1.3 Add `promptRouteRef` to `plugins/mcp-chat/src/routes.ts` and export it
+- [ ] 3.3 Add `promptRouteRef` to `plugins/mcp-chat/src/routes.ts` and export it
       from `src/wiring.ts` alongside a lazy loader for the new page, following the
       existing `chatPageContentLoader` pattern. Verify `yarn tsc:full` passes.
-- [ ] 1.4 Add a second `PageBlueprint` to `plugins/mcp-chat/src/alpha.tsx` bound
+- [ ] 3.4 Add a second `PageBlueprint` to `plugins/mcp-chat/src/alpha.tsx` bound
       to `promptRouteRef`, register it in the plugin's `extensions` and `routes`,
       and leave the existing `mcpChatPage` untouched. Verify by extending
       `src/alpha.test.tsx` so it asserts both pages render at their own paths —
       this covers the scenarios _Both pages are reachable_ and _The new page is
       not mounted_.
 
-## 2. External store adapter and message conversion
+## 4. Streaming client and external store adapter
 
-Covers _Prompt submission_, _Run lifecycle and completion_, _Provider and
+Covers _Prompt submission_, _Run lifecycle and streamed completion_, _Provider and
 transport error handling_ (state layer).
 
-- [ ] 2.1 Add a `usePromptThread` hook holding the turn list, the active
+- [ ] 4.1 Add a streaming method to `src/api/McpChatApi.ts` that posts to
+      `/chat/stream`, parses the event stream, and surfaces typed events to the
+      caller, accepting an `AbortSignal`. Leave `sendChatMessage` and every other
+      existing method untouched. Verify with tests over a well-formed stream, a
+      stream ending in failure, and an aborted stream.
+- [ ] 4.2 Add a `usePromptThread` hook holding the turn list, the active
       `conversationId`, the in-flight `AbortController` and the running flag.
       Verify with unit tests asserting a submitted prompt is appended and a blank
       prompt is not — scenarios _A prompt is submitted_ and _An empty prompt is
       rejected_.
-- [ ] 2.2 Implement `convertMessage`, mapping a view-model turn to
-      `ThreadMessageLike`: the reply as a `text` part, and each
-      `ToolExecutionResult` as a `tool-call` part (`id` → `toolCallId`, `name` →
-      `toolName`, `arguments` → `args`, `result` → `result`), with `isError`
-      derived in a single named helper as `design.md` requires. Verify with unit
-      tests over a reply with zero, one and several tool results.
-- [ ] 2.3 Implement `onNew`: append the user turn, call
-      `mcpChatApi.sendChatMessage` with the full prior conversation, the enabled
-      server ids, the abort signal and the active `conversationId`, then append
-      the assistant turn and record the returned `conversationId`. Verify with a
-      test asserting the enabled-server ids reach the API — scenario _A prompt is
-      submitted_.
-- [ ] 2.4 Implement `onCancel` — abort the in-flight request, clear the running
-      flag, and hand the trimmed list back through `setMessages` so the removal
-      survives the next snapshot. Verify with a test asserting no assistant turn
-      is appended and no trailing user turn is left — scenario _A run is
-      cancelled_.
-- [ ] 2.5 Guard against concurrent runs so a submit during an active run does not
-      interleave two runs. Verify with a test — scenario _A prompt is submitted
+- [ ] 4.3 Implement `convertMessage` to `ThreadMessageLike`, mapping accumulated
+      text to a `text` part and each invocation to a `tool-call` part keyed by
+      `toolCallId`, with `isError` read from the tool-result event. Set `status` to
+      `running` while fragments arrive, `complete` on success, and `incomplete`
+      with reason `error` or `cancelled` otherwise. Verify with unit tests over
+      each state.
+- [ ] 4.4 Implement `onNew`: append the user turn, open the stream with the full
+      prior conversation, the enabled server ids, the abort signal and the active
+      `conversationId`, then apply each event to state — appending fragments,
+      inserting a tool-call part on its start event and filling it in place on its
+      result event. Verify with tests — scenarios _A reply renders incrementally_,
+      _An invocation is shown before its result arrives_, _A running invocation
+      receives its result_.
+- [ ] 4.5 Implement `onCancel` — abort the stream, mark the turn cancelled, then
+      hand the trimmed list back through `setMessages` so the removal survives the
+      next snapshot. Verify no partial turn is left marked running — scenario _A run
+      is cancelled_.
+- [ ] 4.6 Guard against concurrent runs so a submit during an active run does not
+      interleave two streams. Verify with a test — scenario _A prompt is submitted
       while a run is active_.
-- [ ] 2.6 Map failures to error state rather than assistant content, keeping the
-      prompt recoverable and distinguishing an unreachable backend from a
-      provider rejection. Verify with tests over both failure shapes and a
-      successful retry — scenarios _The chat provider returns an error_, _The
-      backend is unreachable_, _A retry succeeds after a failure_.
-- [ ] 2.7 Assemble the `ExternalStoreAdapter` and pass it to
+- [ ] 4.7 Map failures to error state rather than assistant content, keeping any
+      partial text and marking it interrupted, distinguishing an unreachable
+      backend from a provider failure. Verify with tests — scenarios _The chat
+      provider returns an error_, _The backend is unreachable_, _A run fails after
+      partial output_, _A retry succeeds after a failure_.
+- [ ] 4.8 Assemble the `ExternalStoreAdapter` and pass it to
       `useExternalStoreRuntime` with exactly the handler set `design.md` fixes —
       `messages`, `convertMessage`, `isRunning`, `isLoading`, `onNew`,
       `setMessages`, `onEdit`, `onReload`, `onCancel` — leaving
@@ -66,106 +128,116 @@ transport error handling_ (state layer).
       `onAddToolResult` and `adapters.threadList`. Verify `yarn tsc:full` passes
       with no `unstable_` or deprecated member referenced.
 
-## 3. Thread surface
+## 5. Thread surface
 
-Covers _Prompt submission_, _Run lifecycle and completion_, _Provider and
+Covers _Prompt submission_, _Run lifecycle and streamed completion_, _Provider and
 transport error handling_ (presentation).
 
-- [ ] 3.1 Build the composer from `ComposerPrimitive` with multi-line input,
+- [ ] 5.1 Build the composer from `ComposerPrimitive` with multi-line input,
       submit-on-Enter and newline-on-Shift-Enter, styled with a CSS module over
       BUI tokens. Verify with a test driving `screen` queries and `findBy*` —
       scenario _A prompt is submitted_.
-- [ ] 3.2 Build the message list and viewport from `ThreadPrimitive` and
-      `MessagePrimitive`, rendering assistant text as markdown. Verify with a test
-      asserting a completed reply renders as formatted text — scenario _A run
-      completes successfully_.
-- [ ] 3.3 Render the running indicator and the cancel control from the runtime's
+- [ ] 5.2 Build the message list and viewport from `ThreadPrimitive` and
+      `MessagePrimitive`, rendering assistant text as markdown, including while it
+      is still growing. Verify with tests — scenarios _A reply renders
+      incrementally_ and _A run completes successfully_.
+- [ ] 5.3 Render the running indicator and the cancel control from the runtime's
       running state. Verify with a test asserting both appear while a run is in
       flight and clear afterwards — scenario _A run is in progress_.
-- [ ] 3.4 Render run failures as an error distinct from assistant content, with a
-      retry control. Verify with a test — scenarios _The chat provider returns an
-      error_ and _The backend is unreachable_.
-- [ ] 3.5 Confirm no file added under `src/components/PromptPage` imports
+- [ ] 5.4 Render run failures as an error distinct from assistant content, with a
+      retry control, preserving any partial text. Verify with tests — scenarios
+      _The chat provider returns an error_, _The backend is unreachable_, _A run
+      fails after partial output_.
+- [ ] 5.5 Verify a non-streaming provider's single-fragment reply renders and
+      completes normally, with a test — scenario _A non-streaming provider is
+      used_.
+- [ ] 5.6 Confirm no file added under `src/components/PromptPage` imports
       `@backstage/core-components`, `@mui/material` or `@mui/icons-material`.
       Verify with `grep` over the new directory and with `yarn lint --fix`
       reporting clean.
 
-## 4. MCP tool call rendering
+## 6. MCP tool call rendering
 
 Covers _MCP tool call rendering_.
 
-- [ ] 4.1 Register one catch-all tool UI via `makeAssistantToolUI` rendering a
+- [ ] 6.1 Register one catch-all tool UI via `makeAssistantToolUI` rendering a
       tool-call part's name collapsed by default, expandable to its arguments and
       result, in BUI with `@remixicon/react` icons. Verify with tests over one and
       several invocations, asserting independent expansion — scenarios _A single
       tool is invoked_ and _Several tools are invoked in one turn_.
-- [ ] 4.2 Add the copy affordance for an expanded result, with acknowledgement.
+- [ ] 6.2 Render an invocation whose `result` is still absent as running, and let
+      it resolve in place. Verify with tests — scenarios _An invocation is shown
+      before its result arrives_ and _A running invocation receives its result_.
+- [ ] 6.3 Add the copy affordance for an expanded result, with acknowledgement.
       Verify with a test asserting the clipboard write and the acknowledgement —
       scenario _A tool result is copied_.
-- [ ] 4.3 Style a failed invocation distinctly and expose its error detail on
+- [ ] 6.4 Style a failed invocation distinctly and expose its error detail on
       expansion. Verify with a test — scenario _A tool invocation fails_.
-- [ ] 4.4 Verify a reply with no tool results renders no tool-call section, with a
+- [ ] 6.5 Verify a reply with no tool results renders no tool-call section, with a
       test — scenario _No tool is invoked_.
 
-## 5. Revising and regenerating
+## 7. Revising and regenerating
 
 Covers _Revising and regenerating turns_.
 
-- [ ] 5.1 Implement `onEdit` — truncate the list to the edited user turn and
-      re-run from its new text — and surface it through the message action bar and
-      edit composer primitives. Verify with a test — scenario _A user turn is
+- [ ] 7.1 Implement `onEdit` — truncate the list to the edited user turn and
+      re-stream from its new text — and surface it through the message action bar
+      and edit composer primitives. Verify with a test — scenario _A user turn is
       edited and re-run_.
-- [ ] 5.2 Implement `onReload` for the latest user turn and surface a regenerate
+- [ ] 7.2 Implement `onReload` for the latest user turn and surface a regenerate
       action. Verify with a test asserting a second answer is produced for the
       same prompt — scenario _An answer is regenerated_.
-- [ ] 5.3 Render `BranchPickerPrimitive` so a turn with several answers shows its
+- [ ] 7.3 Render `BranchPickerPrimitive` so a turn with several answers shows its
       position and allows moving between them, keeping `setMessages` wired so a
       switch survives the next snapshot. Verify with a test — scenario _Moving
       between alternative answers_.
 
-## 6. Reduced side panel
+## 8. Reduced side panel
 
 Covers _MCP server selection and provider status_ and _Selecting an existing
 conversation_.
 
-- [ ] 6.1 Build the MCP server toggle list on `useMcpServers`, feeding the enabled
+- [ ] 8.1 Build the MCP server toggle list on `useMcpServers`, feeding the enabled
       ids into the adapter's run parameters, without reusing the Material UI
       `ActiveMcpServers` view. Verify with a test asserting a disabled server's id
       is absent from the next request — scenario _A server is disabled_.
-- [ ] 6.2 Build the read-only provider status block on `useProviderStatus`,
-      showing connection state and reported model name with no control to change
-      them, and reporting unavailability without blocking the composer. Verify
-      with tests — scenarios _Provider status is shown_ and _Provider status
-      cannot be loaded_.
-- [ ] 6.3 Build the conversation list on `useConversations`, ordered most recently
+- [ ] 8.2 Build the read-only provider status block on `useProviderStatus`,
+      showing connection state, reported model name and whether the provider
+      streams incrementally, with no control to change them, and reporting
+      unavailability without blocking the composer. Verify with tests — scenarios
+      _Provider status is shown_ and _Provider status cannot be loaded_.
+- [ ] 8.3 Build the conversation list on `useConversations`, ordered most recently
       updated first, with pinned conversations grouped ahead of the rest. Selecting
       one calls `loadConversation` and pushes its turns and id into the thread
       state; "new conversation" clears both. Verify with tests — scenarios _An
       existing conversation is selected_ and _A fresh conversation is started_.
-- [ ] 6.4 Wire the search field to `useConversations`' `searchQuery`. Verify with a
+- [ ] 8.4 Wire the search field to `useConversations`' `searchQuery`. Verify with a
       test asserting case-insensitive narrowing over titles and user turns —
       scenario _The list is searched_.
-- [ ] 6.5 Wire pin and delete to `toggleStar` and `deleteConversation`, including
+- [ ] 8.5 Wire pin and delete to `toggleStar` and `deleteConversation`, including
       the rollback-and-inform path on a failed delete. Verify with tests —
       scenarios _A conversation is pinned_ and _A conversation is deleted_.
-- [ ] 6.6 Handle the empty and non-owning-identity cases so the panel reports an
+- [ ] 8.6 Handle the empty and non-owning-identity cases so the panel reports an
       empty list without an error and the composer still accepts a prompt. Verify
       with a test — scenario _The user has no stored conversations_.
 
-## 7. Workspace verification and release artifacts
+## 9. Workspace verification and release artifacts
 
-- [ ] 7.1 Re-run `yarn dedupe`, then `CI=true yarn test` and `yarn tsc:full`, in
+- [ ] 9.1 Re-run `yarn dedupe`, then `CI=true yarn test` and `yarn tsc:full`, in
       that order, and confirm all three pass. Order matters: dedupe rewrites
       resolved versions, so earlier test and type results do not carry over.
-- [ ] 7.2 Run `yarn lint --fix` and `yarn prettier --write` over the changed
+- [ ] 9.2 Run `yarn lint --fix` and `yarn prettier --write` over the changed
       paths, and confirm every new `.ts`/`.tsx` file carries the Apache 2.0
       header with the current year, without touching the year on existing files.
-- [ ] 7.3 Run `yarn build:api-reports` and commit the updated report, since
-      `src/wiring.ts` and `src/alpha.tsx` gain public exports.
-- [ ] 7.4 Add a changeset for `@alithya-oss/backstage-plugin-mcp-chat` describing
+- [ ] 9.3 Run `yarn build:api-reports` and commit the updated reports for every
+      package whose public API changed — the frontend plugin, `mcp-chat-common`
+      and `mcp-chat-node` at minimum.
+- [ ] 9.4 Add a changeset for `@alithya-oss/backstage-plugin-mcp-chat` describing
       the new page for adopters and calling out the narrowed React peer range as a
-      breaking change with its migration note.
-- [ ] 7.5 Confirm the diff touches no backend package and none of
-      `src/api/McpChatApi.ts`, `src/types.ts`, `src/components/ChatContainer/**`,
-      `src/components/RightPane/**` or `src/components/ChatPage/**`. Verify with
-      `git diff --stat`.
+      breaking change with its migration note. Confirm the backend changesets from
+      2.7 are present.
+- [ ] 9.5 Confirm the diff leaves `POST /chat`'s behaviour, `sendChatMessage`, and
+      `src/components/ChatContainer/**`, `src/components/RightPane/**`,
+      `src/components/ChatPage/**` unchanged. Verify with `git diff --stat`.
+- [ ] 9.6 Confirm deployment ordering is documented for adopters: the backend
+      packages must ship before the new page is mounted.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Planning artifacts only for the OpenSpec change `add-mcp-chat-prompt-page`, the
first stage of the Assistant UI prompt page for `mcp-chat`. **No plugin code is
modified** — nothing under `workspaces/` is touched, so no workspace CI matrix
job is triggered and no changeset is needed.

`openspec/changes/add-mcp-chat-prompt-page/` contains `proposal.md`,
`specs/mcp-chat/prompt-page/spec.md`, `design.md` and `tasks.md`.
`openspec validate add-mcp-chat-prompt-page --strict` passes with zero issues.

### Two open questions settled

**Conversation search and pinning are kept, but not on top of Assistant UI's
thread list.** Verified against `@assistant-ui/react@0.15.16`:
`ExternalStoreThreadListAdapter` has no search notion, and its status model is
exactly `regular | archived`, so `isStarred` has nowhere to live — mapping star
onto `archived` would also be wrong, since the backend only offers
`DELETE /conversations/:id` and has no archive concept. The `adapters.threadList`
slot and its `threadId` / `onSwitchToThread` / `onSwitchToNewThread` members are
each marked `@deprecated ... might change without notice`. The reduced side panel
therefore keeps its own conversation list over the existing `useConversations`
hook, which already implements search, star and delete. Both features survive and
the plugin takes on no unstable API.

**Incremental token streaming is deferred, and this is a known gap against the
parent issue's acceptance criteria.** `POST /chat` in `chatRoutes.ts` awaits
`mcpClientService.processQuery(...)` and answers once with a single JSON body;
`McpChatApi.sendChatMessage` returns `Promise<ChatResponse>`. Streaming cannot be
delivered from the frontend alone, and a new backend endpoint is explicitly out
of scope for this change. The spec states the non-requirement explicitly so that
adding streaming later changes no other requirement.

### Also worth a reviewer's attention

The design drops `onAddToolResult` from the handler set the parent issue
sketched. That handler exists to return *client-side* tool results to the
runtime; in `mcp-chat` every tool runs server-side inside `processQuery` and its
result already arrives in the response, so nothing would ever call it. Enabling
the tracker that drives it (`unstable_enableToolInvocations`) would make the
runtime try to dispatch our server-side tool calls a second time.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. — **n/a**, no
      published package is touched
- [x] Added or updated documentation — the OpenSpec artifacts are the deliverable
- [ ] Tests for new functionality and regression tests for bug fixes — **n/a**,
      specification only; `tasks.md` assigns a verification to every task
- [ ] Screenshots attached (for UI changes) — **n/a**, no UI in this PR
- [x] All your commits have a `Signed-off-by` line in the message.
