### PR TITLE
OSS-16 feat(mcp-chat): streaming seam on LLMProvider and shared stream event types

### DIFF
--- a/openspec/changes/add-mcp-chat-prompt-page/tasks.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/tasks.md
@@ -9,19 +9,19 @@ endpoint before the page that consumes it.
 
 Covers _Providers without native streaming_.
 
-- [ ] 1.1 Add shared stream event payload types to `plugins/mcp-chat-common`
+- [x] 1.1 Add shared stream event payload types to `plugins/mcp-chat-common`
       (text fragment, tool-call, tool-result, terminal completion, terminal
       failure) plus a streaming capability flag on provider status, so backend and
       frontend cannot drift. Verify with `yarn tsc:full`.
-- [ ] 1.2 Add a **concrete** `streamMessage` to the `LLMProvider` base class in
+- [x] 1.2 Add a **concrete** `streamMessage` to the `LLMProvider` base class in
       `plugins/mcp-chat-node`, defaulting to awaiting the existing `sendMessage`
       and emitting the whole reply as one fragment, plus `supportsStreaming()`
       returning `false`. Do **not** make either abstract. Verify that all nine
       `mcp-chat-backend-module-*` packages still typecheck untouched with
       `yarn tsc:full` — that is the whole point of the default implementation.
-- [ ] 1.3 Surface `supportsStreaming()` on the provider status payload. Verify with
+- [x] 1.3 Surface `supportsStreaming()` on the provider status payload. Verify with
       a test — scenario _Streaming capability is reported_.
-- [ ] 1.4 Add tests proving the fallback path yields exactly one fragment then the
+- [x] 1.4 Add tests proving the fallback path yields exactly one fragment then the
       terminal event — scenario _A provider does not stream natively_.
 
 ## 2. Streaming chat endpoint

--- a/workspaces/mcp-chat/.changeset/fifty-donkeys-listen.md
+++ b/workspaces/mcp-chat/.changeset/fifty-donkeys-listen.md
@@ -1,0 +1,19 @@
+---
+'@alithya-oss/backstage-plugin-mcp-chat-common': minor
+'@alithya-oss/backstage-plugin-mcp-chat-node': minor
+'@alithya-oss/backstage-plugin-mcp-chat-backend': patch
+---
+
+Added the streaming seam that the upcoming streaming chat endpoint builds on.
+
+`mcp-chat-common` now exports the stream event payload types (`ChatStreamEvent`
+and its members) so backend and frontend share one wire contract.
+
+`LLMProvider` gains a concrete `streamMessage` and a `supportsStreaming()`
+returning `false`. Neither is abstract, so every existing provider module keeps
+compiling and streaming works everywhere from day one: the default
+implementation awaits `sendMessage` and emits the whole reply as a single
+fragment. A provider adds genuine incremental output by overriding both.
+
+Provider status now carries `supportsStreaming`, letting a client tell real
+streaming from that single-fragment fallback.

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/plugin.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/plugin.test.ts
@@ -133,6 +133,7 @@ describe('mcpChatPlugin', () => {
             getModel: () => 'gpt-4o-mini',
             getBaseUrl: () => 'https://api.openai.com/v1',
             supportsNativeMcp: () => false,
+            supportsStreaming: () => false,
             setMcpServerConfigs: jest.fn(),
             getLastResponseOutput: () => null,
           } as any);

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.test.ts
@@ -57,6 +57,7 @@ describe('MCPClientServiceImpl', () => {
       getModel: jest.fn().mockReturnValue('gpt-4'),
       getBaseUrl: jest.fn().mockReturnValue('https://api.openai.com/v1'),
       supportsNativeMcp: jest.fn().mockReturnValue(false),
+      supportsStreaming: jest.fn().mockReturnValue(false),
       setMcpServerConfigs: jest.fn(),
       getLastResponseOutput: jest.fn().mockReturnValue(null),
     };

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/ProviderStatusReporter.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/ProviderStatusReporter.test.ts
@@ -30,6 +30,7 @@ describe('ProviderStatusReporter', () => {
       getType: jest.fn().mockReturnValue('openai'),
       getModel: jest.fn().mockReturnValue('gpt-4'),
       getBaseUrl: jest.fn().mockReturnValue('https://api.openai.com/v1'),
+      supportsStreaming: jest.fn().mockReturnValue(false),
     };
   });
 
@@ -119,6 +120,23 @@ describe('ProviderStatusReporter', () => {
 
       expect(status.providers).toEqual([]);
       expect(status.summary.error).toBe('Unknown error');
+    });
+
+    it('reports whether the active provider streams incrementally', async () => {
+      mockLLMProvider.testConnection.mockResolvedValue({ connected: true });
+      mockLLMProvider.supportsStreaming.mockReturnValue(true);
+
+      reporter = new ProviderStatusReporter({
+        logger: mockLogger,
+        llmProvider: mockLLMProvider,
+      });
+
+      const streaming = await reporter.getProviderStatus();
+      expect(streaming.providers[0].supportsStreaming).toBe(true);
+
+      mockLLMProvider.supportsStreaming.mockReturnValue(false);
+      const fallback = await reporter.getProviderStatus();
+      expect(fallback.providers[0].supportsStreaming).toBe(false);
     });
 
     it('logs a warning when testConnection throws', async () => {

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/ProviderStatusReporter.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/ProviderStatusReporter.ts
@@ -46,6 +46,7 @@ export class ProviderStatusReporter {
             models: status.models || [],
             error: status.error,
           },
+          supportsStreaming: this.llmProvider.supportsStreaming(),
         },
       ];
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-common/report.api.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-common/report.api.md
@@ -30,6 +30,54 @@ export interface ChatResponse {
 }
 
 // @public
+export interface ChatStreamCompleteEvent {
+  conversationId?: string;
+  toolsUsed: string[];
+  type: 'complete';
+}
+
+// @public
+export interface ChatStreamErrorEvent {
+  message: string;
+  type: 'error';
+}
+
+// @public
+export type ChatStreamEvent =
+  | ChatStreamTextEvent
+  | ChatStreamToolCallEvent
+  | ChatStreamToolResultEvent
+  | ChatStreamTerminalEvent;
+
+// @public
+export type ChatStreamTerminalEvent =
+  | ChatStreamCompleteEvent
+  | ChatStreamErrorEvent;
+
+// @public
+export interface ChatStreamTextEvent {
+  text: string;
+  type: 'text';
+}
+
+// @public
+export interface ChatStreamToolCallEvent {
+  arguments: Record<string, unknown>;
+  id: string;
+  name: string;
+  serverId: string;
+  type: 'tool-call';
+}
+
+// @public
+export interface ChatStreamToolResultEvent {
+  id: string;
+  isError: boolean;
+  result: string;
+  type: 'tool-result';
+}
+
+// @public
 export interface ConversationRecord {
   createdAt: Date;
   id: string;
@@ -130,6 +178,7 @@ export interface ProviderInfo {
   connection: ProviderConnectionStatus;
   id: string;
   model: string;
+  supportsStreaming?: boolean;
 }
 
 // @public

--- a/workspaces/mcp-chat/plugins/mcp-chat-common/src/index.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-common/src/index.ts
@@ -42,6 +42,15 @@ export type {
   ChatResponse,
   QueryResponse,
 
+  // Chat streaming types
+  ChatStreamTextEvent,
+  ChatStreamToolCallEvent,
+  ChatStreamToolResultEvent,
+  ChatStreamCompleteEvent,
+  ChatStreamErrorEvent,
+  ChatStreamTerminalEvent,
+  ChatStreamEvent,
+
   // Tool types
   Tool,
   ToolCall,

--- a/workspaces/mcp-chat/plugins/mcp-chat-common/src/types.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-common/src/types.ts
@@ -214,6 +214,14 @@ export interface ProviderInfo {
   baseUrl: string;
   /** Current connection status */
   connection: ProviderConnectionStatus;
+  /**
+   * Whether the provider produces incremental output.
+   *
+   * When `false`, the streaming chat endpoint still answers with a valid
+   * stream, delivering the whole reply as a single text event. This lets a
+   * client tell genuine streaming from that single-fragment fallback.
+   */
+  supportsStreaming?: boolean;
 }
 
 /**
@@ -451,6 +459,116 @@ export interface ToolExecutionResult {
   /** ID of the MCP server that executed the tool */
   serverId: string;
 }
+
+// =============================================================================
+// Chat Streaming Types
+// =============================================================================
+
+/**
+ * An incremental fragment of the assistant reply.
+ *
+ * Fragments arrive in reply order, so concatenating their `text` in arrival
+ * order reproduces the complete reply.
+ *
+ * @public
+ */
+export interface ChatStreamTextEvent {
+  /** Event discriminant */
+  type: 'text';
+  /** Reply text produced since the previous text event */
+  text: string;
+}
+
+/**
+ * Announces an MCP tool invocation that is about to run.
+ *
+ * Emitted before the tool executes, so a client can show an invocation as
+ * running before its outcome exists.
+ *
+ * @public
+ */
+export interface ChatStreamToolCallEvent {
+  /** Event discriminant */
+  type: 'tool-call';
+  /** Correlation id, shared with the matching tool-result event */
+  id: string;
+  /** Name of the tool being invoked */
+  name: string;
+  /** Parsed arguments passed to the tool */
+  arguments: Record<string, unknown>;
+  /** ID of the MCP server that will run the tool */
+  serverId: string;
+}
+
+/**
+ * Carries the outcome of an MCP tool invocation.
+ *
+ * Never precedes the {@link ChatStreamToolCallEvent} bearing the same `id`.
+ *
+ * @public
+ */
+export interface ChatStreamToolResultEvent {
+  /** Event discriminant */
+  type: 'tool-result';
+  /** Correlation id of the tool-call event this result belongs to */
+  id: string;
+  /** Result returned by the tool, or the error detail when `isError` is true */
+  result: string;
+  /** Whether the invocation failed or timed out */
+  isError: boolean;
+}
+
+/**
+ * Terminal event of a run that produced a reply.
+ *
+ * @public
+ */
+export interface ChatStreamCompleteEvent {
+  /** Event discriminant */
+  type: 'complete';
+  /** ID of the persisted conversation. Absent when nothing was stored. */
+  conversationId?: string;
+  /** Names of the tools invoked during the run */
+  toolsUsed: string[];
+}
+
+/**
+ * Terminal event of a run that failed.
+ *
+ * Fragments already sent before the failure are not retracted.
+ *
+ * @public
+ */
+export interface ChatStreamErrorEvent {
+  /** Event discriminant */
+  type: 'error';
+  /** Human-readable failure message */
+  message: string;
+}
+
+/**
+ * Terminal event of a streamed run. Exactly one is sent, and no event follows
+ * it.
+ *
+ * @public
+ */
+export type ChatStreamTerminalEvent =
+  | ChatStreamCompleteEvent
+  | ChatStreamErrorEvent;
+
+/**
+ * Any event carried by the streaming chat endpoint.
+ *
+ * The `type` discriminant doubles as the server-sent event name, so backend and
+ * frontend read the same wire contract from this one union.
+ *
+ * @public
+ */
+export type ChatStreamEvent =
+  | ChatStreamTextEvent
+  | ChatStreamToolCallEvent
+  | ChatStreamToolResultEvent
+  | ChatStreamTerminalEvent;
 
 // =============================================================================
 // Validation Types

--- a/workspaces/mcp-chat/plugins/mcp-chat-node/report.api.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-node/report.api.md
@@ -94,8 +94,14 @@ export abstract class LLMProvider {
   ): Promise<ChatResponse>;
   // (undocumented)
   setMcpServerConfigs(_configs: MCPServerFullConfig[]): void;
+  streamMessage(
+    messages: ChatMessage[],
+    tools?: Tool[],
+    options?: LLMStreamOptions,
+  ): AsyncGenerator<LLMStreamChunk, void, undefined>;
   // (undocumented)
   supportsNativeMcp(): boolean;
+  supportsStreaming(): boolean;
   // (undocumented)
   protected temperature?: number;
   // (undocumented)
@@ -117,6 +123,26 @@ export interface LlmProviderExtensionPoint {
 
 // @public
 export const llmProviderExtensionPoint: ExtensionPoint<LlmProviderExtensionPoint>;
+
+// @public
+export type LLMStreamChunk = LLMStreamTextChunk | LLMStreamResponseChunk;
+
+// @public
+export interface LLMStreamOptions {
+  signal?: AbortSignal;
+}
+
+// @public
+export interface LLMStreamResponseChunk {
+  response: ChatResponse;
+  type: 'response';
+}
+
+// @public
+export interface LLMStreamTextChunk {
+  text: string;
+  type: 'text';
+}
 
 export { MCPServer };
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-node/src/LLMProvider.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-node/src/LLMProvider.test.ts
@@ -15,7 +15,13 @@
  */
 
 import { LLMProvider } from './LLMProvider';
-import type { ChatMessage, ChatResponse, Tool, ProviderConfig } from './types';
+import type {
+  ChatMessage,
+  ChatResponse,
+  Tool,
+  ProviderConfig,
+  LLMStreamChunk,
+} from './types';
 
 /**
  * Concrete test subclass that exposes `makeRequest` for testing.
@@ -312,6 +318,96 @@ describe('LLMProvider', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('streaming fallback', () => {
+    it('reports no native streaming support by default', () => {
+      expect(createProvider().supportsStreaming()).toBe(false);
+    });
+
+    it('emits exactly one text fragment then the response chunk', async () => {
+      const response: ChatResponse = {
+        choices: [
+          { message: { role: 'assistant', content: 'The whole reply.' } },
+        ],
+      };
+      const provider = createProvider();
+      const sendMessage = jest
+        .spyOn(provider, 'sendMessage')
+        .mockResolvedValue(response);
+      const tools: Tool[] = [
+        {
+          type: 'function',
+          function: { name: 'list_files', description: 'x', parameters: {} },
+        },
+      ];
+      const messages: ChatMessage[] = [{ role: 'user', content: 'hi' }];
+
+      const chunks: LLMStreamChunk[] = [];
+      for await (const chunk of provider.streamMessage(messages, tools)) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([
+        { type: 'text', text: 'The whole reply.' },
+        { type: 'response', response },
+      ]);
+      expect(chunks.filter(c => c.type === 'text')).toHaveLength(1);
+      expect(sendMessage).toHaveBeenCalledWith(messages, tools);
+    });
+
+    it('emits only the response chunk when the reply carries no text', async () => {
+      const response: ChatResponse = {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'list_files', arguments: '{}' },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      const provider = createProvider();
+      jest.spyOn(provider, 'sendMessage').mockResolvedValue(response);
+
+      const chunks: LLMStreamChunk[] = [];
+      for await (const chunk of provider.streamMessage([
+        { role: 'user', content: 'hi' },
+      ])) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([{ type: 'response', response }]);
+    });
+
+    it('emits nothing once the caller has aborted', async () => {
+      const provider = createProvider();
+      const controller = new AbortController();
+      jest.spyOn(provider, 'sendMessage').mockImplementation(async () => {
+        controller.abort();
+        return {
+          choices: [{ message: { role: 'assistant', content: 'too late' } }],
+        };
+      });
+
+      const chunks: LLMStreamChunk[] = [];
+      for await (const chunk of provider.streamMessage(
+        [{ role: 'user', content: 'hi' }],
+        undefined,
+        { signal: controller.signal },
+      )) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([]);
     });
   });
 });

--- a/workspaces/mcp-chat/plugins/mcp-chat-node/src/LLMProvider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-node/src/LLMProvider.ts
@@ -22,6 +22,8 @@ import {
   ChatResponse,
   ProviderConfig,
   MCPServerFullConfig,
+  LLMStreamChunk,
+  LLMStreamOptions,
 } from './types';
 
 /**
@@ -86,6 +88,50 @@ export abstract class LLMProvider {
 
   supportsNativeMcp(): boolean {
     return false;
+  }
+
+  /**
+   * Whether this provider produces incremental output.
+   *
+   * `false` on the base class, because the default `streamMessage` delivers the
+   * whole reply as a single fragment. A provider that streams natively
+   * overrides this method together with `streamMessage`.
+   *
+   * Surfaced on provider status so a client can tell genuine streaming from the
+   * single-fragment fallback.
+   */
+  supportsStreaming(): boolean {
+    return false;
+  }
+
+  /**
+   * Streams a reply as a sequence of chunks: zero or more text fragments in
+   * reply order, then exactly one `response` chunk carrying the complete
+   * response including any tool calls the provider requested.
+   *
+   * This method is deliberately concrete, not abstract: the default
+   * implementation awaits `sendMessage` and emits its reply as a single
+   * fragment, so every provider is streamable without implementing anything.
+   * Overriding it — together with `supportsStreaming()` — is what turns on
+   * genuine incremental output.
+   */
+  async *streamMessage(
+    messages: ChatMessage[],
+    tools?: Tool[],
+    options?: LLMStreamOptions,
+  ): AsyncGenerator<LLMStreamChunk, void, undefined> {
+    const response = await this.sendMessage(messages, tools);
+
+    if (options?.signal?.aborted) {
+      return;
+    }
+
+    const content = response.choices[0]?.message?.content;
+    if (content) {
+      yield { type: 'text', text: content };
+    }
+
+    yield { type: 'response', response };
   }
 
   setMcpServerConfigs(_configs: MCPServerFullConfig[]): void {

--- a/workspaces/mcp-chat/plugins/mcp-chat-node/src/index.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-node/src/index.ts
@@ -36,6 +36,13 @@ export {
 
 export type { ProviderConfig } from './types';
 
+export type {
+  LLMStreamTextChunk,
+  LLMStreamResponseChunk,
+  LLMStreamChunk,
+  LLMStreamOptions,
+} from './types';
+
 // Re-exports from common package (via types.ts)
 export type {
   CommonProviderConfig,

--- a/workspaces/mcp-chat/plugins/mcp-chat-node/src/types.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-node/src/types.ts
@@ -15,7 +15,10 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { ProviderConfig as CommonProviderConfig } from '@alithya-oss/backstage-plugin-mcp-chat-common';
+import {
+  ProviderConfig as CommonProviderConfig,
+  ChatResponse,
+} from '@alithya-oss/backstage-plugin-mcp-chat-common';
 
 // =============================================================================
 // Extended Provider Configuration (Node-only)
@@ -30,6 +33,60 @@ import { ProviderConfig as CommonProviderConfig } from '@alithya-oss/backstage-p
 export interface ProviderConfig extends CommonProviderConfig {
   /** Logger instance for diagnostic output */
   logger: LoggerService;
+}
+
+// =============================================================================
+// Provider Streaming (Node-only)
+// =============================================================================
+
+/**
+ * An incremental fragment of provider output.
+ *
+ * @public
+ */
+export interface LLMStreamTextChunk {
+  /** Chunk discriminant */
+  type: 'text';
+  /** Reply text produced since the previous chunk */
+  text: string;
+}
+
+/**
+ * The complete provider response, emitted once after every text chunk.
+ *
+ * Carries any tool calls the provider requested, so the caller can keep driving
+ * its tool-calling loop from the same stream.
+ *
+ * @public
+ */
+export interface LLMStreamResponseChunk {
+  /** Chunk discriminant */
+  type: 'response';
+  /** The provider's complete response for this turn */
+  response: ChatResponse;
+}
+
+/**
+ * A chunk emitted by {@link LLMProvider.streamMessage}.
+ *
+ * @public
+ */
+export type LLMStreamChunk = LLMStreamTextChunk | LLMStreamResponseChunk;
+
+/**
+ * Options accepted by {@link LLMProvider.streamMessage}.
+ *
+ * @public
+ */
+export interface LLMStreamOptions {
+  /**
+   * Signals that the caller has stopped consuming the stream.
+   *
+   * A provider that streams natively passes it to its own request. The default
+   * fallback cannot interrupt an in-flight `sendMessage`, but stops emitting
+   * once it is aborted.
+   */
+  signal?: AbortSignal;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Group 1 of `openspec/changes/add-mcp-chat-prompt-page/tasks.md` — the provider
streaming seam. Covers the **Providers without native streaming** requirement of
`specs/mcp-chat/chat-streaming/spec.md`. Backend only; it opens the way for the
SSE endpoint (group 2) without touching the nine provider modules.

- `mcp-chat-common` exports the stream event payload types — `ChatStreamTextEvent`,
  `ChatStreamToolCallEvent`, `ChatStreamToolResultEvent`, the terminal
  `ChatStreamCompleteEvent` / `ChatStreamErrorEvent` and the `ChatStreamEvent`
  union — so backend and frontend read one wire contract. `ProviderInfo` gains an
  optional `supportsStreaming` flag.
- `LLMProvider` gains a **concrete** `streamMessage` and `supportsStreaming()`.
  Neither is abstract: the default awaits `sendMessage` and emits the whole reply
  as a single fragment followed by the complete response, so every provider is
  streamable today and each can opt into genuine incremental output later by
  overriding both. This is why all nine `mcp-chat-backend-module-*` packages are
  untouched.
- `ProviderStatusReporter` reports the capability, letting a client tell real
  streaming from the single-fragment fallback.

Three existing test files gained `supportsStreaming` on their hand-rolled
`LLMProvider` mocks; no production behaviour changed there.

Verified in `workspaces/mcp-chat`: `yarn tsc:full` passes, `CI=true yarn test`
passes (55 suites, 617 tests), `yarn dedupe --check` is clean (no dependency
change), and `openspec validate add-mcp-chat-prompt-page --strict` still passes.

Closes OSS-16.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
