### PR TITLE
OSS-17 feat(mcp-chat): SSE POST /chat/stream with MCP tool events

### DIFF
--- a/openspec/changes/add-mcp-chat-prompt-page/tasks.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/tasks.md
@@ -29,32 +29,32 @@ Covers _Providers without native streaming_.
 Covers _Streaming chat endpoint_, _Stream event sequence_, _Cancellation and
 disconnection_, _Authorization and persistence parity_.
 
-- [ ] 2.1 Factor the parts of `QueryProcessor.processQuery` both paths need —
+- [x] 2.1 Factor the parts of `QueryProcessor.processQuery` both paths need —
       system-prompt injection and tool filtering by enabled server id — into
       helpers, so the streaming variant reuses them instead of copying. Verify
       existing tests still pass unchanged.
-- [ ] 2.2 Add a streaming query path emitting a text event per provider fragment,
+- [x] 2.2 Add a streaming query path emitting a text event per provider fragment,
       a tool-call event before each MCP invocation and a tool-result event after
       it, correlated by invocation id, then exactly one terminal event. Verify with
       tests — scenarios _A reply is streamed without tools_, _A tool is invoked
       mid-run_, _A tool invocation fails_.
-- [ ] 2.3 Add the `POST /chat/stream` route emitting `text/event-stream` with
+- [x] 2.3 Add the `POST /chat/stream` route emitting `text/event-stream` with
       no-buffering headers, validating the body exactly as `POST /chat` does before
       opening the stream. Verify with tests — scenarios _A streaming request is
       accepted_ and _The request is invalid_.
-- [ ] 2.4 Tie an `AbortController` to client disconnect: abandon the provider
+- [x] 2.4 Tie an `AbortController` to client disconnect: abandon the provider
       request, start no further tool invocation, and persist nothing for the
       cancelled run. Verify with tests — scenarios _The client disconnects
       mid-stream_ and _A cancelled run is not stored_.
-- [ ] 2.5 Apply the same credentials and persistence rules as `POST /chat`,
+- [x] 2.5 Apply the same credentials and persistence rules as `POST /chat`,
       including guest skipping and title generation for a new conversation, and
       keep a persistence failure from failing the run. Verify with tests —
       scenarios _An authenticated user streams a reply_, _A guest user streams a
       reply_, _Persistence fails_.
-- [ ] 2.6 Confirm `POST /chat` is untouched and still passes its existing tests —
+- [x] 2.6 Confirm `POST /chat` is untouched and still passes its existing tests —
       scenario _The non-streaming endpoint is unaffected_. Verify with
       `git diff` on `chatRoutes.ts` showing only additive changes.
-- [ ] 2.7 Add a changeset for each backend package touched
+- [x] 2.7 Add a changeset for each backend package touched
       (`mcp-chat-backend`, `mcp-chat-node`, `mcp-chat-common`) describing the new
       endpoint and the provider seam for adopters.
 

--- a/workspaces/mcp-chat/.changeset/mcp-chat-streaming-endpoint.md
+++ b/workspaces/mcp-chat/.changeset/mcp-chat-streaming-endpoint.md
@@ -1,0 +1,24 @@
+---
+'@alithya-oss/backstage-plugin-mcp-chat-backend': minor
+---
+
+Added `POST /chat/stream`, a server-sent event endpoint that delivers the same
+run as `POST /chat` while it happens: a `text` event per reply fragment, a
+`tool-call` event before each MCP invocation and a `tool-result` event after it —
+correlated by invocation id — then exactly one terminal `complete` or `error`
+event. Payload shapes come from `ChatStreamEvent` in
+`@alithya-oss/backstage-plugin-mcp-chat-common`.
+
+It takes the same request body as `POST /chat`, validates it identically before
+opening the stream, and applies the same identity and persistence rules: stored
+for an authenticated non-guest user with a title generated for a new
+conversation, skipped for a guest, and a storage failure never fails the run.
+Disconnecting abandons the provider request, starts no further tool invocation,
+and persists nothing.
+
+Every configured provider is streamable: one that does not stream natively is
+served by the `LLMProvider` fallback, which delivers its reply as a single
+fragment, so clients need no second code path. `MCPClientService` gains
+`streamQuery` alongside the unchanged `processQuery`.
+
+`POST /chat` is unchanged — same request, same response, same behaviour.

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/plugin.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/plugin.test.ts
@@ -92,6 +92,12 @@ jest.mock('./utils', () => ({
   validateMessages: jest.fn().mockReturnValue({ isValid: true }),
   isGuestUser: jest.fn().mockReturnValue(true),
   isMissingTableError: jest.fn().mockReturnValue(false),
+  // The chat routes validate through this helper; keep the real one so the
+  // payloads below are rejected with their real messages.
+  validateChatRequest: jest.requireActual('./utils/validateChatRequest')
+    .validateChatRequest,
+  // Stands in for a guest run: nothing is stored, no conversation id reported.
+  saveChatConversation: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockConfig = {

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/router.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/router.test.ts
@@ -35,6 +35,7 @@ describe('createRouter', () => {
     mcpClientService = {
       initializeMCPServers: jest.fn(),
       processQuery: jest.fn(),
+      streamQuery: jest.fn(),
       getAvailableTools: jest.fn(),
       getProviderStatus: jest.fn(),
       getMCPServerStatus: jest.fn(),

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/routes/chatRoutes.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/routes/chatRoutes.test.ts
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices } from '@backstage/backend-test-utils';
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+import request from 'supertest';
+import { createRouter } from '../router';
+import { MCPClientService } from '../services/MCPClientService';
+import { ChatConversationStore } from '../services/ChatConversationStore';
+import { SummarizationService } from '../services/SummarizationService';
+
+/** A frame of the server-sent event stream. */
+type SseFrame = { event: string; data: any };
+
+/** Parses an SSE body into its frames, asserting each carries both lines. */
+const parseSse = (raw: string): SseFrame[] =>
+  raw
+    .split('\n\n')
+    .filter(frame => frame.trim().length > 0)
+    .map(frame => {
+      const lines = frame.split('\n');
+      const name = lines.find(line => line.startsWith('event: '));
+      const data = lines.find(line => line.startsWith('data: '));
+      if (!name || !data) {
+        throw new Error(`Malformed SSE frame: ${JSON.stringify(frame)}`);
+      }
+      return {
+        event: name.slice('event: '.length),
+        data: JSON.parse(data.slice('data: '.length)),
+      };
+    });
+
+/** Turns a fixed list of chunks into the generator streamQuery returns. */
+const streamOf = (...chunks: any[]) =>
+  async function* () {
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  };
+
+const USER_TURN = [{ role: 'user', content: 'Hello' }];
+const CONVERSATION_ID = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+
+describe('POST /chat/stream', () => {
+  let app: express.Express;
+  let mcpClientService: jest.Mocked<MCPClientService>;
+  let conversationStore: jest.Mocked<ChatConversationStore>;
+  let summarizationService: jest.Mocked<SummarizationService>;
+  let httpAuth: ReturnType<typeof mockServices.httpAuth.mock>;
+
+  beforeEach(async () => {
+    mcpClientService = {
+      initializeMCPServers: jest.fn(),
+      processQuery: jest.fn(),
+      streamQuery: jest.fn(),
+      getAvailableTools: jest.fn(),
+      getProviderStatus: jest.fn(),
+      getMCPServerStatus: jest.fn(),
+    };
+
+    conversationStore = {
+      saveConversation: jest.fn().mockResolvedValue({ id: CONVERSATION_ID }),
+      updateTitle: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<ChatConversationStore>;
+
+    summarizationService = {
+      summarizeConversation: jest.fn().mockResolvedValue('Test Title'),
+    } as unknown as jest.Mocked<SummarizationService>;
+
+    httpAuth = mockServices.httpAuth.mock();
+    httpAuth.credentials.mockResolvedValue({
+      principal: { type: 'user', userEntityRef: 'user:default/mock' },
+    } as any);
+
+    app = express();
+    app.use(
+      await createRouter({
+        logger: mockServices.logger.mock(),
+        mcpClientService,
+        conversationStore,
+        httpAuth,
+        summarizationService,
+      }),
+    );
+  });
+
+  describe('a streaming request is accepted', () => {
+    it('answers an event stream with anti-buffering headers, forwarding tool events before exactly one terminal event', async () => {
+      mcpClientService.streamQuery.mockImplementation(
+        streamOf(
+          { type: 'text', text: 'Looking' },
+          {
+            type: 'tool-call',
+            id: 'call_1',
+            name: 'test_tool',
+            arguments: { arg1: 'value1' },
+            serverId: 'test-server',
+          },
+          { type: 'tool-result', id: 'call_1', result: 'ok', isError: false },
+          { type: 'text', text: ' — done' },
+          {
+            type: 'result',
+            result: {
+              reply: 'Looking — done',
+              toolCalls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'test_tool', arguments: '{}' },
+                },
+              ],
+              toolResponses: [],
+            },
+          },
+        ) as any,
+      );
+
+      const response = await request(app)
+        .post('/chat/stream')
+        .send({ messages: USER_TURN, enabledTools: ['test-server'] });
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toBe(
+        'text/event-stream; charset=utf-8',
+      );
+      expect(response.headers['cache-control']).toBe('no-cache, no-transform');
+      expect(response.headers['x-accel-buffering']).toBe('no');
+
+      const frames = parseSse(response.text);
+      expect(frames.map(frame => frame.event)).toEqual([
+        'text',
+        'tool-call',
+        'tool-result',
+        'text',
+        'complete',
+      ]);
+
+      // The tool-call event precedes the result bearing the same id.
+      const callIndex = frames.findIndex(f => f.event === 'tool-call');
+      const resultIndex = frames.findIndex(f => f.event === 'tool-result');
+      expect(callIndex).toBeLessThan(resultIndex);
+      expect(frames[callIndex].data.id).toBe(frames[resultIndex].data.id);
+
+      // Concatenating the fragments reproduces the reply.
+      expect(
+        frames
+          .filter(f => f.event === 'text')
+          .map(f => f.data.text)
+          .join(''),
+      ).toBe('Looking — done');
+
+      // Exactly one terminal event, and nothing after it.
+      expect(
+        frames.filter(f => f.event === 'complete' || f.event === 'error'),
+      ).toHaveLength(1);
+      expect(frames[frames.length - 1].data).toEqual({
+        type: 'complete',
+        conversationId: CONVERSATION_ID,
+        toolsUsed: ['test_tool'],
+      });
+
+      expect(mcpClientService.streamQuery).toHaveBeenCalledWith(
+        USER_TURN,
+        ['test-server'],
+        expect.objectContaining({ signal: expect.anything() }),
+      );
+    });
+
+    it('terminates with a failure event when the provider fails after partial output, without retracting fragments', async () => {
+      mcpClientService.streamQuery.mockImplementation((() =>
+        (async function* () {
+          yield { type: 'text', text: 'Partial answer' };
+          throw new Error('provider exploded');
+        })()) as any);
+
+      const response = await request(app)
+        .post('/chat/stream')
+        .send({ messages: USER_TURN });
+
+      const frames = parseSse(response.text);
+      expect(frames.map(frame => frame.event)).toEqual(['text', 'error']);
+      expect(frames[0].data.text).toBe('Partial answer');
+      expect(frames[1].data).toEqual({
+        type: 'error',
+        message: 'provider exploded',
+      });
+      expect(conversationStore.saveConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the request is invalid', () => {
+    // Every payload the single-response endpoint rejects, so both endpoints are
+    // held to one validation contract.
+    const invalidPayloads: [string, any][] = [
+      ['missing messages', {}],
+      ['messages not an array', { messages: 'nope' }],
+      ['empty messages', { messages: [] }],
+      [
+        'last message not from user',
+        {
+          messages: [
+            { role: 'user', content: 'a' },
+            { role: 'assistant', content: 'b' },
+          ],
+        },
+      ],
+      ['invalid role', { messages: [{ role: 'wizard', content: 'a' }] }],
+      [
+        'enabledTools not an array',
+        { messages: USER_TURN, enabledTools: 'nope' },
+      ],
+      [
+        'enabledTools not all strings',
+        { messages: USER_TURN, enabledTools: [1] },
+      ],
+      [
+        'malformed conversation id',
+        { messages: USER_TURN, conversationId: 'not-a-uuid' },
+      ],
+    ];
+
+    it.each(invalidPayloads)(
+      'rejects %s identically on both endpoints, before opening a stream',
+      async (_label, payload) => {
+        const streamed = await request(app).post('/chat/stream').send(payload);
+        const single = await request(app).post('/chat').send(payload);
+
+        expect(streamed.status).toBe(400);
+        expect(streamed.status).toBe(single.status);
+        expect(streamed.body).toEqual(single.body);
+        // No stream was opened: this is a plain JSON error response.
+        expect(streamed.headers['content-type']).toMatch(/application\/json/);
+        expect(mcpClientService.streamQuery).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('authorization and persistence parity', () => {
+    beforeEach(() => {
+      mcpClientService.streamQuery.mockImplementation(
+        streamOf(
+          { type: 'text', text: 'Reply' },
+          {
+            type: 'result',
+            result: { reply: 'Reply', toolCalls: [], toolResponses: [] },
+          },
+        ) as any,
+      );
+    });
+
+    it('stores the conversation for an authenticated user and reports its id, generating a title for a new one', async () => {
+      const response = await request(app)
+        .post('/chat/stream')
+        .send({ messages: USER_TURN });
+
+      const frames = parseSse(response.text);
+      expect(frames[frames.length - 1].data).toEqual({
+        type: 'complete',
+        conversationId: CONVERSATION_ID,
+        toolsUsed: [],
+      });
+      expect(conversationStore.saveConversation).toHaveBeenCalledWith(
+        'user:default/mock',
+        [...USER_TURN, { role: 'assistant', content: 'Reply' }],
+        undefined,
+        undefined,
+      );
+
+      // Title generation is fire-and-forget for a newly created conversation.
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+      expect(summarizationService.summarizeConversation).toHaveBeenCalled();
+      expect(conversationStore.updateTitle).toHaveBeenCalledWith(
+        'user:default/mock',
+        CONVERSATION_ID,
+        'Test Title',
+      );
+    });
+
+    it('stores nothing for a guest and completes without a conversation id', async () => {
+      httpAuth.credentials.mockResolvedValue({
+        principal: { type: 'user', userEntityRef: 'user:development/guest' },
+      } as any);
+
+      const response = await request(app)
+        .post('/chat/stream')
+        .send({ messages: USER_TURN });
+
+      const frames = parseSse(response.text);
+      expect(frames.map(f => f.event)).toEqual(['text', 'complete']);
+      expect(frames[1].data).toEqual({ type: 'complete', toolsUsed: [] });
+      expect(conversationStore.saveConversation).not.toHaveBeenCalled();
+    });
+
+    it('still reaches the completion event when persistence fails', async () => {
+      conversationStore.saveConversation.mockRejectedValue(
+        new Error('database is on fire'),
+      );
+
+      const response = await request(app)
+        .post('/chat/stream')
+        .send({ messages: USER_TURN });
+
+      const frames = parseSse(response.text);
+      expect(response.status).toBe(200);
+      expect(frames.map(f => f.event)).toEqual(['text', 'complete']);
+      expect(frames[0].data.text).toBe('Reply');
+      expect(frames[1].data).toEqual({ type: 'complete', toolsUsed: [] });
+    });
+  });
+
+  describe('cancellation and disconnection', () => {
+    it('stores nothing when a run ends without reaching its terminal chunk', async () => {
+      // An aborted run yields no result chunk — the route must not persist it.
+      mcpClientService.streamQuery.mockImplementation(
+        streamOf({ type: 'text', text: 'Partial' }) as any,
+      );
+
+      const response = await request(app)
+        .post('/chat/stream')
+        .send({ messages: USER_TURN });
+
+      const frames = parseSse(response.text);
+      expect(frames.map(f => f.event)).toEqual(['text']);
+      expect(conversationStore.saveConversation).not.toHaveBeenCalled();
+    });
+
+    it('aborts the run when the client disconnects mid-stream', async () => {
+      let signal: AbortSignal | undefined;
+      const aborted = new Promise<void>(resolve => {
+        mcpClientService.streamQuery.mockImplementation(((
+          _messages: any,
+          _enabled: any,
+          options: any,
+        ) =>
+          (async function* () {
+            signal = options.signal;
+            yield { type: 'text', text: 'Partial' };
+            // Hold the run open until the client goes away.
+            await new Promise<void>(done => {
+              signal!.addEventListener('abort', () => {
+                resolve();
+                done();
+              });
+            });
+            // No result chunk: the run was abandoned.
+          })()) as any);
+      });
+
+      const server = http.createServer(app);
+      await new Promise<void>(resolve => server.listen(0, resolve));
+      const { port } = server.address() as AddressInfo;
+
+      const body = JSON.stringify({ messages: USER_TURN });
+      const clientRequest = http.request({
+        port,
+        path: '/chat/stream',
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+      });
+
+      clientRequest.on('error', () => {
+        /* destroying the request is the point of this test */
+      });
+      clientRequest.on('response', res => {
+        // Drop the connection as soon as the first fragment arrives.
+        res.once('data', () => clientRequest.destroy());
+      });
+      clientRequest.end(body);
+
+      await aborted;
+
+      expect(signal?.aborted).toBe(true);
+      expect(conversationStore.saveConversation).not.toHaveBeenCalled();
+
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    });
+  });
+});

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/routes/chatRoutes.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/routes/chatRoutes.ts
@@ -15,14 +15,17 @@
  */
 
 import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
-import { InputError } from '@backstage/errors';
 import express from 'express';
 import Router from 'express-promise-router';
-import { validate as uuidValidate } from 'uuid';
+import {
+  ChatMessage,
+  ChatStreamEvent,
+  QueryResponse,
+} from '@alithya-oss/backstage-plugin-mcp-chat-common';
 import { MCPClientService } from '../services/MCPClientService';
 import { ChatConversationStore } from '../services/ChatConversationStore';
 import { SummarizationService } from '../services/SummarizationService';
-import { validateMessages, isGuestUser, isMissingTableError } from '../utils';
+import { validateChatRequest, saveChatConversation } from '../utils';
 
 /**
  * Dependencies required for chat routes.
@@ -36,8 +39,36 @@ export interface ChatRoutesDeps {
 }
 
 /**
+ * Builds the conversation to persist: the caller's turns plus the assistant's
+ * reply, carrying the tool calls it requested.
+ */
+function withAssistantTurn(
+  messages: ChatMessage[],
+  result: QueryResponse,
+): ChatMessage[] {
+  return [
+    ...messages,
+    {
+      role: 'assistant' as const,
+      content: result.reply,
+      tool_calls: result.toolCalls.length > 0 ? result.toolCalls : undefined,
+    },
+  ];
+}
+
+/**
+ * Names of the tools a run invoked.
+ */
+function toolNamesOf(result: QueryResponse): string[] {
+  return result.toolCalls.length > 0
+    ? result.toolCalls.map(call => call.function.name)
+    : [];
+}
+
+/**
  * Creates Express router for chat endpoints.
- * Provides POST /chat endpoint for sending messages to the LLM.
+ * Provides POST /chat endpoint for sending messages to the LLM, and
+ * POST /chat/stream for the same run delivered as server-sent events.
  *
  * @param deps - Route dependencies
  * @returns Express router
@@ -57,102 +88,28 @@ export function createChatRoutes(deps: ChatRoutesDeps): express.Router {
    * Process a chat message through the LLM with optional tool usage.
    */
   router.post('/', async (req, res) => {
-    const { messages, enabledTools, conversationId } = req.body;
-
-    // Validate conversationId format if provided
-    if (conversationId && !uuidValidate(conversationId)) {
-      throw new InputError('Invalid conversation ID format');
-    }
-
-    const validation = validateMessages(messages, logger);
-    if (!validation.isValid) {
-      logger.warn(`Message validation failed: ${validation.error}`);
-      throw new InputError(validation.error!);
-    }
-
-    if (enabledTools && !Array.isArray(enabledTools)) {
-      throw new InputError('enabledTools must be an array');
-    }
-
-    if (
-      enabledTools &&
-      enabledTools.some((tool: any) => typeof tool !== 'string')
-    ) {
-      throw new InputError('All enabledTools must be strings');
-    }
+    const { messages, enabledTools, conversationId } = validateChatRequest(
+      req.body,
+      logger,
+    );
 
     const { reply, toolCalls, toolResponses } =
       await mcpClientService.processQuery(messages, enabledTools);
 
-    const toolsUsed =
-      toolCalls.length > 0 ? toolCalls.map(call => call.function.name) : [];
-
-    // Create conversation messages with assistant response
-    const conversationMessages = [
-      ...messages,
-      {
-        role: 'assistant' as const,
-        content: reply,
-        tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
-      },
-    ];
+    const result: QueryResponse = { reply, toolCalls, toolResponses };
+    const toolsUsed = toolNamesOf(result);
 
     // Save conversation for authenticated non-guest users
-    let savedConversationId: string | undefined;
-    let userId: string | undefined;
-    try {
-      const credentials = await httpAuth.credentials(req, {
-        allow: ['user'],
-        allowLimitedAccess: true,
-      });
-
-      userId = credentials.principal.userEntityRef;
-
-      if (!isGuestUser(userId)) {
-        const savedConversation = await conversationStore.saveConversation(
-          userId,
-          conversationMessages,
-          toolsUsed.length > 0 ? toolsUsed : undefined,
-          conversationId,
-        );
-        savedConversationId = savedConversation.id;
-
-        // Fire-and-forget: Generate title asynchronously
-        // This doesn't block the response to the user
-        if (savedConversationId && !conversationId) {
-          // Only generate title for new conversations
-          const convId = savedConversationId;
-          const convUserId = userId;
-
-          setImmediate(async () => {
-            try {
-              // Generate title using LLM
-              const title = await summarizationService.summarizeConversation(
-                conversationMessages,
-              );
-
-              // Update title in database
-              await conversationStore.updateTitle(convUserId, convId, title);
-
-              logger.debug(
-                `Generated title for conversation ${convId}: "${title}"`,
-              );
-            } catch (titleError) {
-              logger.warn(
-                `Failed to generate title for ${convId}: ${titleError}`,
-              );
-            }
-          });
-        }
-      }
-    } catch (error: any) {
-      // Don't fail the request if saving fails
-      if (isMissingTableError(error)) {
-        logger.warn('Conversations table does not exist yet');
-      } else {
-        logger.error(`Failed to save conversation: ${error}`);
-      }
-    }
+    const savedConversationId = await saveChatConversation({
+      req,
+      conversationMessages: withAssistantTurn(messages, result),
+      toolsUsed,
+      conversationId,
+      conversationStore,
+      summarizationService,
+      httpAuth,
+      logger,
+    });
 
     return res.json({
       role: 'assistant',
@@ -161,6 +118,101 @@ export function createChatRoutes(deps: ChatRoutesDeps): express.Router {
       toolsUsed,
       conversationId: savedConversationId,
     });
+  });
+
+  /**
+   * POST /chat/stream
+   * Same run as POST /chat, delivered as server-sent events: a text event per
+   * reply fragment, a tool-call event before each MCP invocation and a
+   * tool-result event after it, then exactly one terminal event.
+   *
+   * The body is validated exactly as POST /chat validates it, before any stream
+   * is opened, so an invalid request still gets a normal JSON error response.
+   */
+  router.post('/stream', async (req, res) => {
+    // Validate before opening the stream: once headers are sent, an error can
+    // only be reported as a terminal event, never as a status code.
+    const { messages, enabledTools, conversationId } = validateChatRequest(
+      req.body,
+      logger,
+    );
+
+    // Client disconnect abandons the provider request and stops the tool loop.
+    const controller = new AbortController();
+    res.on('close', () => {
+      if (!res.writableEnded) {
+        controller.abort();
+      }
+    });
+
+    res.status(200);
+    res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+    // no-transform and X-Accel-Buffering keep proxies from buffering the stream
+    // and defeating incremental delivery.
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders();
+
+    const send = (event: ChatStreamEvent) => {
+      if (res.writableEnded) {
+        return;
+      }
+      // The event's discriminant doubles as the SSE event name; the data frame
+      // carries the whole payload so a client can read either.
+      res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+    };
+
+    let result: QueryResponse | undefined;
+    try {
+      for await (const event of mcpClientService.streamQuery(
+        messages,
+        enabledTools,
+        { signal: controller.signal },
+      )) {
+        if (event.type === 'result') {
+          result = event.result;
+          break;
+        }
+        send(event);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Streamed chat run failed: ${message}`);
+      // Fragments already sent are not retracted — the failure event just
+      // terminates the stream.
+      if (!controller.signal.aborted) {
+        send({ type: 'error', message });
+      }
+      res.end();
+      return;
+    }
+
+    // A cancelled run reaches no terminal chunk: nothing is persisted, and the
+    // stream is simply released.
+    if (controller.signal.aborted || !result) {
+      logger.debug('Streamed chat run cancelled before completion');
+      res.end();
+      return;
+    }
+
+    const savedConversationId = await saveChatConversation({
+      req,
+      conversationMessages: withAssistantTurn(messages, result),
+      toolsUsed: toolNamesOf(result),
+      conversationId,
+      conversationStore,
+      summarizationService,
+      httpAuth,
+      logger,
+    });
+
+    send({
+      type: 'complete',
+      conversationId: savedConversationId,
+      toolsUsed: toolNamesOf(result),
+    });
+    res.end();
   });
 
   return router;

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientService.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientService.ts
@@ -22,6 +22,7 @@ import {
   QueryResponse,
   ServerTool,
 } from '@alithya-oss/backstage-plugin-mcp-chat-common';
+import type { QueryStreamEvent, QueryStreamOptions } from './QueryProcessor';
 
 /**
  * Service interface for MCP (Model Context Protocol) client operations.
@@ -81,6 +82,38 @@ export interface MCPClientService {
     messagesInput: ChatMessage[],
     enabledTools?: string[],
   ): Promise<QueryResponse>;
+
+  /**
+   * Streams a chat query through the LLM provider, surfacing the reply as it is
+   * produced and each MCP tool invocation as it happens.
+   *
+   * Emits a text chunk per provider fragment, a tool-call chunk before every MCP
+   * invocation and a tool-result chunk after it — correlated by invocation id —
+   * then exactly one terminal `result` chunk carrying the complete outcome.
+   *
+   * An aborted run stops without a terminal chunk, which is how the caller knows
+   * not to persist it.
+   *
+   * @param messagesInput - Array of chat messages representing the conversation
+   * @param enabledTools - Optional array of server IDs to enable. Same semantics as {@link MCPClientService.processQuery}.
+   * @param options - Stream options, notably the abort signal tied to client disconnect
+   * @returns Async generator of stream chunks
+   *
+   * @example
+   * ```typescript
+   * const controller = new AbortController();
+   * for await (const event of service.streamQuery(messages, ['kubernetes-server'], {
+   *   signal: controller.signal,
+   * })) {
+   *   if (event.type === 'text') process.stdout.write(event.text);
+   * }
+   * ```
+   */
+  streamQuery(
+    messagesInput: ChatMessage[],
+    enabledTools?: string[],
+    options?: QueryStreamOptions,
+  ): AsyncGenerator<QueryStreamEvent, void, undefined>;
 
   /**
    * Returns all tools available from connected MCP servers.

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.ts
@@ -30,6 +30,7 @@ import {
 import { McpServerLifecycle } from './McpServerLifecycle';
 import { McpTransportFactory } from './McpTransportFactory';
 import { QueryProcessor } from './QueryProcessor';
+import type { QueryStreamEvent, QueryStreamOptions } from './QueryProcessor';
 import { ProviderStatusReporter } from './ProviderStatusReporter';
 import { McpServerStatusReporter } from './McpServerStatusReporter';
 
@@ -108,6 +109,18 @@ export class MCPClientServiceImpl implements MCPClientService {
     enabledTools?: string[],
   ): Promise<QueryResponse> {
     return this.queryProcessor.processQuery(messagesInput, enabledTools);
+  }
+
+  streamQuery(
+    messagesInput: any[],
+    enabledTools?: string[],
+    options?: QueryStreamOptions,
+  ): AsyncGenerator<QueryStreamEvent, void, undefined> {
+    return this.queryProcessor.streamQuery(
+      messagesInput,
+      enabledTools,
+      options,
+    );
   }
 
   getAvailableTools(): ServerTool[] {

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/QueryProcessor.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/QueryProcessor.test.ts
@@ -40,6 +40,7 @@ describe('QueryProcessor', () => {
 
     mockLLMProvider = {
       sendMessage: jest.fn(),
+      streamMessage: jest.fn(),
       supportsNativeMcp: jest.fn().mockReturnValue(false),
       setMcpServerConfigs: jest.fn(),
       getLastResponseOutput: jest.fn().mockReturnValue(null),
@@ -380,6 +381,253 @@ describe('QueryProcessor', () => {
         result: 'tool output',
         serverId: 'server-1',
       });
+    });
+  });
+
+  describe('streamQuery', () => {
+    /** Builds a provider stream from a list of chunks. */
+    const streamOf = (...chunks: any[]) =>
+      jest.fn(async function* () {
+        for (const chunk of chunks) {
+          yield chunk;
+        }
+      });
+
+    const textChunk = (text: string) => ({ type: 'text', text });
+    const responseChunk = (message: any) => ({
+      type: 'response',
+      response: { choices: [{ message }] },
+    });
+
+    const drain = async (
+      generator: AsyncGenerator<any, void, undefined>,
+    ): Promise<any[]> => {
+      const events: any[] = [];
+      for await (const event of generator) {
+        events.push(event);
+      }
+      return events;
+    };
+
+    const toolCall: ToolCall = {
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'test_tool', arguments: '{"arg1":"value1"}' },
+    };
+
+    it('streams a reply in order and terminates once when no tool is used', async () => {
+      mockLLMProvider.streamMessage = streamOf(
+        textChunk('Hello'),
+        textChunk(', '),
+        textChunk('world'),
+        responseChunk({ role: 'assistant', content: 'Hello, world' }),
+      );
+
+      const events = await drain(
+        processor.streamQuery([{ role: 'user', content: 'Hi' }]),
+      );
+
+      expect(events.map(event => event.type)).toEqual([
+        'text',
+        'text',
+        'text',
+        'result',
+      ]);
+      expect(
+        events
+          .filter(event => event.type === 'text')
+          .map(event => event.text)
+          .join(''),
+      ).toBe('Hello, world');
+      expect(events[events.length - 1].result).toEqual({
+        reply: 'Hello, world',
+        toolCalls: [],
+        toolResponses: [],
+      });
+      expect(events.filter(event => event.type === 'result')).toHaveLength(1);
+    });
+
+    it('emits a single text event for a provider that does not stream natively', async () => {
+      // The base-class fallback shape: whole reply as one fragment.
+      mockLLMProvider.streamMessage = streamOf(
+        textChunk('One shot reply'),
+        responseChunk({ role: 'assistant', content: 'One shot reply' }),
+      );
+
+      const events = await drain(
+        processor.streamQuery([{ role: 'user', content: 'Hi' }]),
+      );
+
+      expect(events).toEqual([
+        { type: 'text', text: 'One shot reply' },
+        {
+          type: 'result',
+          result: {
+            reply: 'One shot reply',
+            toolCalls: [],
+            toolResponses: [],
+          },
+        },
+      ]);
+    });
+
+    it('announces a tool invocation before its result and streams the follow-up reply', async () => {
+      mockLLMProvider.streamMessage = jest
+        .fn()
+        .mockImplementationOnce(async function* () {
+          yield responseChunk({
+            role: 'assistant',
+            content: null,
+            tool_calls: [toolCall],
+          });
+        })
+        .mockImplementationOnce(async function* () {
+          yield textChunk('Based on ');
+          yield textChunk('the tool');
+          yield responseChunk({
+            role: 'assistant',
+            content: 'Based on the tool',
+          });
+        });
+
+      const events = await drain(
+        processor.streamQuery([{ role: 'user', content: 'Use a tool' }]),
+      );
+
+      expect(events.map(event => event.type)).toEqual([
+        'tool-call',
+        'tool-result',
+        'text',
+        'text',
+        'result',
+      ]);
+      expect(events[0]).toEqual({
+        type: 'tool-call',
+        id: 'call_1',
+        name: 'test_tool',
+        arguments: { arg1: 'value1' },
+        serverId: 'test-server',
+      });
+      expect(events[1]).toEqual({
+        type: 'tool-result',
+        id: 'call_1',
+        result: 'tool result',
+        isError: false,
+      });
+      expect(events[events.length - 1].result).toMatchObject({
+        reply: 'Based on the tool',
+        toolCalls: [toolCall],
+      });
+    });
+
+    it('marks a failed tool invocation and still reaches the terminal chunk', async () => {
+      utils.executeToolCall.mockRejectedValue(new Error('tool exploded'));
+      mockLLMProvider.streamMessage = jest
+        .fn()
+        .mockImplementationOnce(async function* () {
+          yield responseChunk({
+            role: 'assistant',
+            content: null,
+            tool_calls: [toolCall],
+          });
+        })
+        .mockImplementationOnce(async function* () {
+          yield textChunk('Sorry, that failed');
+          yield responseChunk({
+            role: 'assistant',
+            content: 'Sorry, that failed',
+          });
+        });
+
+      const events = await drain(
+        processor.streamQuery([{ role: 'user', content: 'Use a tool' }]),
+      );
+
+      const toolResult = events.find(event => event.type === 'tool-result');
+      expect(toolResult).toEqual({
+        type: 'tool-result',
+        id: 'call_1',
+        result: "Error executing tool 'test_tool': tool exploded",
+        isError: true,
+      });
+      expect(events[events.length - 1]).toMatchObject({
+        type: 'result',
+        result: { reply: 'Sorry, that failed' },
+      });
+    });
+
+    it('starts no further tool invocation and emits no terminal chunk once aborted', async () => {
+      const controller = new AbortController();
+      mockLLMProvider.streamMessage = jest
+        .fn()
+        .mockImplementationOnce(async function* () {
+          yield textChunk('Partial');
+          yield responseChunk({
+            role: 'assistant',
+            content: null,
+            tool_calls: [toolCall],
+          });
+        });
+
+      const events: any[] = [];
+      for await (const event of processor.streamQuery(
+        [{ role: 'user', content: 'Use a tool' }],
+        undefined,
+        { signal: controller.signal },
+      )) {
+        events.push(event);
+        // Cancel as soon as the first fragment lands.
+        controller.abort();
+      }
+
+      expect(events).toEqual([{ type: 'text', text: 'Partial' }]);
+      expect(utils.executeToolCall).not.toHaveBeenCalled();
+      expect(events.some(event => event.type === 'result')).toBe(false);
+      // Only the first pass ran; no follow-up request was made.
+      expect(mockLLMProvider.streamMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('replays a native-MCP provider run as tool events followed by its reply', async () => {
+      mockLLMProvider.supportsNativeMcp.mockReturnValue(true);
+      mockLLMProvider.sendMessage.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'Native reply',
+              tool_calls: [toolCall],
+            },
+          },
+        ],
+      });
+      mockLLMProvider.getLastResponseOutput.mockReturnValue([
+        {
+          type: 'mcp_call',
+          id: 'mcp_1',
+          name: 'tool1',
+          arguments: '{"key":"value"}',
+          output: 'tool output',
+          server_label: 'server-1',
+        },
+      ]);
+
+      const events = await drain(
+        processor.streamQuery([{ role: 'user', content: 'Use a tool' }]),
+      );
+
+      expect(events.map(event => event.type)).toEqual([
+        'tool-call',
+        'tool-result',
+        'text',
+        'result',
+      ]);
+      expect(events[1]).toEqual({
+        type: 'tool-result',
+        id: 'mcp_1',
+        result: 'tool output',
+        isError: false,
+      });
+      expect(events[2]).toEqual({ type: 'text', text: 'Native reply' });
     });
   });
 });

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/QueryProcessor.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/QueryProcessor.ts
@@ -25,7 +25,55 @@ import {
   QueryResponse,
   ServerTool,
   ResponsesApiMcpCall,
+  ChatStreamTextEvent,
+  ChatStreamToolCallEvent,
+  ChatStreamToolResultEvent,
 } from '@alithya-oss/backstage-plugin-mcp-chat-common';
+
+/**
+ * Terminal chunk of a streamed query, carrying the run's complete outcome so
+ * the caller can persist the conversation and build the wire terminal event.
+ *
+ * Internal to the backend: it is not part of the server-sent event contract,
+ * because only the route knows whether a conversation was stored.
+ *
+ * @public
+ */
+export interface QueryStreamResultEvent {
+  /** Chunk discriminant */
+  type: 'result';
+  /** The run's complete reply, tool calls and tool results */
+  result: QueryResponse;
+}
+
+/**
+ * A chunk yielded by {@link QueryProcessor.streamQuery}.
+ *
+ * The first three members are the wire events the route forwards verbatim; the
+ * last is the internal terminal chunk the route consumes rather than forwards.
+ *
+ * @public
+ */
+export type QueryStreamEvent =
+  | ChatStreamTextEvent
+  | ChatStreamToolCallEvent
+  | ChatStreamToolResultEvent
+  | QueryStreamResultEvent;
+
+/**
+ * Options accepted by {@link QueryProcessor.streamQuery}.
+ *
+ * @public
+ */
+export interface QueryStreamOptions {
+  /**
+   * Signals that the client has gone away or cancelled.
+   *
+   * Passed through to the provider, and checked before every MCP invocation so
+   * an abandoned run starts no further tool call.
+   */
+  signal?: AbortSignal;
+}
 
 /**
  * Options for creating a QueryProcessor instance.
@@ -67,10 +115,14 @@ export class QueryProcessor {
     this.getServerConfigs = options.getServerConfigs;
   }
 
-  async processQuery(
-    messagesInput: any[],
-    enabledTools?: string[],
-  ): Promise<QueryResponse> {
+  /**
+   * Returns the conversation with the configured system prompt prepended,
+   * unless the caller already supplied one.
+   *
+   * Shared by the single-response and streaming paths so both inject the prompt
+   * on identical terms.
+   */
+  private withSystemPrompt(messagesInput: any[]): ChatMessage[] {
     const messages: ChatMessage[] = [...messagesInput];
     if (messages.length === 0 || messages[0].role !== 'system') {
       messages.unshift({
@@ -78,11 +130,21 @@ export class QueryProcessor {
         content: this.systemPrompt,
       });
     }
+    return messages;
+  }
 
-    if (this.llmProvider.supportsNativeMcp()) {
-      return this.processQueryWithResponsesApi(messages, enabledTools);
-    }
-
+  /**
+   * Resolves the tool inventory for a run: every known tool for routing an
+   * invocation to its MCP server, and the subset offered to the provider once
+   * filtered by enabled server id and stripped of `serverId`.
+   *
+   * Shared by the single-response and streaming paths so both offer the
+   * provider exactly the same tools.
+   */
+  private resolveTools(enabledTools?: string[]): {
+    tools: ServerTool[];
+    llmTools: Tool[];
+  } {
     const tools = this.getTools();
 
     // Filter tools based on enabled servers
@@ -93,6 +155,35 @@ export class QueryProcessor {
 
     // Remove serverId from tools when sending to LLM
     const llmTools: Tool[] = filteredTools.map(({ serverId, ...tool }) => tool);
+
+    return { tools, llmTools };
+  }
+
+  /**
+   * Narrows the configured MCP servers to those the caller enabled.
+   *
+   * Shared by the single-response and streaming variants of the Responses API
+   * path.
+   */
+  private resolveServerConfigs(enabledTools?: string[]): MCPServerFullConfig[] {
+    const serverConfigs = this.getServerConfigs();
+
+    return enabledTools !== undefined && enabledTools !== null
+      ? serverConfigs.filter(config => enabledTools.includes(config.id))
+      : serverConfigs;
+  }
+
+  async processQuery(
+    messagesInput: any[],
+    enabledTools?: string[],
+  ): Promise<QueryResponse> {
+    const messages = this.withSystemPrompt(messagesInput);
+
+    if (this.llmProvider.supportsNativeMcp()) {
+      return this.processQueryWithResponsesApi(messages, enabledTools);
+    }
+
+    const { tools, llmTools } = this.resolveTools(enabledTools);
 
     const response = await this.llmProvider.sendMessage(messages, llmTools);
     const replyMessage = response.choices[0].message;
@@ -175,6 +266,208 @@ export class QueryProcessor {
   }
 
   /**
+   * Streams a query, surfacing the run as it happens: a text event per provider
+   * fragment, a tool-call event before each MCP invocation and a tool-result
+   * event after it — correlated by invocation id — then exactly one terminal
+   * `result` chunk carrying the complete outcome.
+   *
+   * Reuses the same system-prompt injection and tool filtering as
+   * {@link QueryProcessor.processQuery}, so both paths offer the provider
+   * identical input.
+   *
+   * Concatenating the `text` of every emitted text event reproduces
+   * `result.reply`, so what a client rendered is exactly what gets persisted.
+   *
+   * Yields nothing further once `options.signal` is aborted, and starts no
+   * further tool invocation — an abandoned run therefore never reaches its
+   * terminal chunk, which is what tells the caller not to persist it.
+   */
+  async *streamQuery(
+    messagesInput: any[],
+    enabledTools?: string[],
+    options?: QueryStreamOptions,
+  ): AsyncGenerator<QueryStreamEvent, void, undefined> {
+    const signal = options?.signal;
+    const messages = this.withSystemPrompt(messagesInput);
+
+    if (this.llmProvider.supportsNativeMcp()) {
+      // The Responses API runs tools internally and answers in one piece, so
+      // its outcome is replayed as events rather than streamed.
+      const result = await this.processQueryWithResponsesApi(
+        messages,
+        enabledTools,
+      );
+      if (signal?.aborted) return;
+
+      for (const toolResponse of result.toolResponses) {
+        yield {
+          type: 'tool-call',
+          id: toolResponse.id,
+          name: toolResponse.name,
+          arguments: toolResponse.arguments ?? {},
+          serverId: toolResponse.serverId,
+        };
+        yield {
+          type: 'tool-result',
+          id: toolResponse.id,
+          result: String(toolResponse.result ?? ''),
+          isError: Boolean((toolResponse as { error?: unknown }).error),
+        };
+      }
+
+      if (result.reply) {
+        yield { type: 'text', text: result.reply };
+      }
+      yield { type: 'result', result };
+      return;
+    }
+
+    const { tools, llmTools } = this.resolveTools(enabledTools);
+
+    let reply = '';
+    const toolResponses: QueryResponse['toolResponses'] = [];
+
+    // First pass: stream the provider's reply, keeping the complete response so
+    // the tool-calling loop can continue from the same stream.
+    let response;
+    for await (const chunk of this.llmProvider.streamMessage(
+      messages,
+      llmTools,
+      { signal },
+    )) {
+      if (signal?.aborted) return;
+      if (chunk.type === 'text') {
+        reply += chunk.text;
+        yield { type: 'text', text: chunk.text };
+      } else {
+        response = chunk.response;
+      }
+    }
+
+    if (signal?.aborted) return;
+
+    const toolCalls = response?.choices[0]?.message?.tool_calls ?? [];
+    this.logger.info(`LLM stream received with ${toolCalls.length} tool calls`);
+
+    for (const toolCall of toolCalls) {
+      // Cancellation must stop the run before it starts another invocation.
+      if (signal?.aborted) return;
+
+      const toolName = toolCall.function.name;
+      const args = this.parseToolArguments(toolCall.function.arguments);
+
+      yield {
+        type: 'tool-call',
+        id: toolCall.id,
+        name: toolName,
+        arguments: args,
+        serverId:
+          tools.find(tool => tool.function.name === toolName)?.serverId ??
+          'unknown',
+      };
+
+      try {
+        const toolResponse = await executeToolCall(
+          toolCall,
+          tools,
+          this.getMcpClients(),
+          this.toolCallTimeout,
+        );
+        toolResponses.push(toolResponse);
+
+        yield {
+          type: 'tool-result',
+          id: toolCall.id,
+          result: toolResponse.result,
+          isError: false,
+        };
+
+        messages.push({
+          role: 'assistant',
+          content: null,
+          tool_calls: [toolCall],
+        });
+        messages.push({
+          role: 'tool',
+          content: toolResponse.result,
+          tool_call_id: toolCall.id,
+        });
+      } catch (error) {
+        // A failed or timed-out tool is reported as a failed result and the run
+        // continues to its terminal chunk, matching the non-streaming path.
+        const errorMessage = `Error executing tool '${toolName}': ${
+          error instanceof Error ? error.message : error
+        }`;
+
+        this.logger.warn(errorMessage);
+
+        toolResponses.push({
+          id: toolCall.id,
+          name: toolName,
+          arguments: args,
+          result: errorMessage,
+          serverId: 'error',
+        });
+
+        yield {
+          type: 'tool-result',
+          id: toolCall.id,
+          result: errorMessage,
+          isError: true,
+        };
+
+        messages.push({
+          role: 'assistant',
+          content: null,
+          tool_calls: [toolCall],
+        });
+        messages.push({
+          role: 'tool',
+          content: errorMessage,
+          tool_call_id: toolCall.id,
+        });
+      }
+    }
+
+    if (toolCalls.length > 0) {
+      if (signal?.aborted) return;
+
+      // Second pass: the reply the provider produces once it has the results.
+      for await (const chunk of this.llmProvider.streamMessage(
+        messages,
+        undefined,
+        { signal },
+      )) {
+        if (signal?.aborted) return;
+        if (chunk.type === 'text') {
+          reply += chunk.text;
+          yield { type: 'text', text: chunk.text };
+        }
+      }
+
+      if (signal?.aborted) return;
+    }
+
+    yield {
+      type: 'result',
+      result: { reply, toolCalls: [...toolCalls], toolResponses },
+    };
+  }
+
+  /**
+   * Parses a tool call's JSON arguments, degrading to an empty object rather
+   * than throwing — malformed arguments must still produce a tool-call event so
+   * the client can show the invocation that is about to fail.
+   */
+  private parseToolArguments(rawArguments?: string): Record<string, unknown> {
+    try {
+      return JSON.parse(rawArguments || '{}');
+    } catch {
+      return {};
+    }
+  }
+
+  /**
    * Process query using OpenAI Responses API.
    * The API handles tool discovery and execution internally.
    */
@@ -182,13 +475,7 @@ export class QueryProcessor {
     messages: ChatMessage[],
     enabledTools?: string[],
   ): Promise<QueryResponse> {
-    const serverConfigs = this.getServerConfigs();
-
-    // Filter server configs based on enabled tools
-    const enabledServerConfigs =
-      enabledTools !== undefined && enabledTools !== null
-        ? serverConfigs.filter(config => enabledTools.includes(config.id))
-        : serverConfigs;
+    const enabledServerConfigs = this.resolveServerConfigs(enabledTools);
 
     // Set the filtered configs on the provider
     this.llmProvider.setMcpServerConfigs(enabledServerConfigs);

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/SummarizationService.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/SummarizationService.test.ts
@@ -47,6 +47,7 @@ describe('SummarizationService', () => {
     mockMcpClientService = {
       initializeMCPServers: jest.fn(),
       processQuery: jest.fn(),
+      streamQuery: jest.fn(),
       getAvailableTools: jest.fn(),
       getProviderStatus: jest.fn(),
       getMCPServerStatus: jest.fn(),

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils/index.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils/index.ts
@@ -22,5 +22,9 @@ export {
   DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS,
 } from './executeToolCall';
 export { validateMessages } from './validateMessages';
+export { validateChatRequest } from './validateChatRequest';
+export type { ValidatedChatRequest } from './validateChatRequest';
+export { saveChatConversation } from './saveChatConversation';
+export type { SaveChatConversationOptions } from './saveChatConversation';
 export { isGuestUser } from './isGuestUser';
 export { isMissingTableError } from './isMissingTableError';

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils/saveChatConversation.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils/saveChatConversation.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
+import express from 'express';
+import { ChatMessage } from '@alithya-oss/backstage-plugin-mcp-chat-common';
+// Type-only: importing the service modules for real would close a cycle back
+// through `services/QueryProcessor`, which imports this barrel's siblings.
+import type { ChatConversationStore } from '../services/ChatConversationStore';
+import type { SummarizationService } from '../services/SummarizationService';
+import { isGuestUser } from './isGuestUser';
+import { isMissingTableError } from './isMissingTableError';
+
+/**
+ * Everything {@link saveChatConversation} needs to store a completed run.
+ *
+ * @public
+ */
+export interface SaveChatConversationOptions {
+  /** The request the run was served from, used to resolve the caller's identity */
+  req: express.Request;
+  /** The conversation including the assistant's turn */
+  conversationMessages: ChatMessage[];
+  /** Names of the tools invoked during the run */
+  toolsUsed: string[];
+  /** ID of the conversation being appended to, or undefined for a new one */
+  conversationId?: string;
+  conversationStore: ChatConversationStore;
+  summarizationService: SummarizationService;
+  httpAuth: HttpAuthService;
+  logger: LoggerService;
+}
+
+/**
+ * Stores a completed conversation for an authenticated non-guest user and, for
+ * a newly created one, kicks off title generation.
+ *
+ * Never throws: a persistence failure is logged and reported as "nothing
+ * stored", so a run that produced a reply is not failed by a storage problem.
+ * Shared by `POST /chat` and `POST /chat/stream` so both persist on identical
+ * terms.
+ *
+ * @returns The stored conversation's ID, or undefined when nothing was stored
+ * @public
+ */
+export async function saveChatConversation(
+  options: SaveChatConversationOptions,
+): Promise<string | undefined> {
+  const {
+    req,
+    conversationMessages,
+    toolsUsed,
+    conversationId,
+    conversationStore,
+    summarizationService,
+    httpAuth,
+    logger,
+  } = options;
+
+  let savedConversationId: string | undefined;
+  let userId: string | undefined;
+  try {
+    const credentials = await httpAuth.credentials(req, {
+      allow: ['user'],
+      allowLimitedAccess: true,
+    });
+
+    userId = credentials.principal.userEntityRef;
+
+    if (!isGuestUser(userId)) {
+      const savedConversation = await conversationStore.saveConversation(
+        userId,
+        conversationMessages,
+        toolsUsed.length > 0 ? toolsUsed : undefined,
+        conversationId,
+      );
+      savedConversationId = savedConversation.id;
+
+      // Fire-and-forget: Generate title asynchronously
+      // This doesn't block the response to the user
+      if (savedConversationId && !conversationId) {
+        // Only generate title for new conversations
+        const convId = savedConversationId;
+        const convUserId = userId;
+
+        setImmediate(async () => {
+          try {
+            // Generate title using LLM
+            const title = await summarizationService.summarizeConversation(
+              conversationMessages,
+            );
+
+            // Update title in database
+            await conversationStore.updateTitle(convUserId, convId, title);
+
+            logger.debug(
+              `Generated title for conversation ${convId}: "${title}"`,
+            );
+          } catch (titleError) {
+            logger.warn(
+              `Failed to generate title for ${convId}: ${titleError}`,
+            );
+          }
+        });
+      }
+    }
+  } catch (error: any) {
+    // Don't fail the request if saving fails
+    if (isMissingTableError(error)) {
+      logger.warn('Conversations table does not exist yet');
+    } else {
+      logger.error(`Failed to save conversation: ${error}`);
+    }
+  }
+
+  return savedConversationId;
+}

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils/validateChatRequest.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils/validateChatRequest.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { InputError } from '@backstage/errors';
+import { validate as uuidValidate } from 'uuid';
+import { ChatMessage } from '@alithya-oss/backstage-plugin-mcp-chat-common';
+import { validateMessages } from './validateMessages';
+
+/**
+ * A chat request body accepted by both the single-response and the streaming
+ * chat endpoints.
+ *
+ * @public
+ */
+export interface ValidatedChatRequest {
+  /** The prior conversation, ending with the user's turn */
+  messages: ChatMessage[];
+  /** IDs of the MCP servers whose tools may be used, or undefined for all */
+  enabledTools?: string[];
+  /** ID of the conversation to append to, or undefined for a new one */
+  conversationId?: string;
+}
+
+/**
+ * Validates a chat request body, throwing {@link @backstage/errors#InputError}
+ * on the first problem found.
+ *
+ * Shared by `POST /chat` and `POST /chat/stream` so a payload one endpoint
+ * rejects is rejected identically by the other — and, for the streaming
+ * endpoint, before any event stream is opened.
+ *
+ * @param body - The raw request body
+ * @param logger - The logger service for diagnostic output
+ * @returns The validated request fields
+ * @public
+ */
+export function validateChatRequest(
+  body: any,
+  logger: LoggerService,
+): ValidatedChatRequest {
+  const { messages, enabledTools, conversationId } = body ?? {};
+
+  // Validate conversationId format if provided
+  if (conversationId && !uuidValidate(conversationId)) {
+    throw new InputError('Invalid conversation ID format');
+  }
+
+  const validation = validateMessages(messages, logger);
+  if (!validation.isValid) {
+    logger.warn(`Message validation failed: ${validation.error}`);
+    throw new InputError(validation.error!);
+  }
+
+  if (enabledTools && !Array.isArray(enabledTools)) {
+    throw new InputError('enabledTools must be an array');
+  }
+
+  if (
+    enabledTools &&
+    enabledTools.some((tool: any) => typeof tool !== 'string')
+  ) {
+    throw new InputError('All enabledTools must be strings');
+  }
+
+  return { messages, enabledTools, conversationId };
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds `POST /chat/stream` to `mcp-chat-backend` — the streaming counterpart of `POST /chat`, delivering the same run as server-sent events so a client can render the reply as it is produced and watch MCP tool invocations happen.

Implements group 2 of `openspec/changes/add-mcp-chat-prompt-page/tasks.md`, covering the *Streaming chat endpoint*, *Stream event sequence*, *Cancellation and disconnection* and *Authorization and persistence parity* requirements. Builds on the provider seam from #236.

### What it does

- **`QueryProcessor.streamQuery`** emits a `text` event per provider fragment, a `tool-call` event **before** each MCP invocation and a `tool-result` event **after** it — correlated by invocation id — then exactly one terminal chunk. Concatenating the fragments reproduces the persisted reply. A failed or timed-out tool is reported as a failed result and the run continues, matching the non-streaming path.
- **`POST /chat/stream`** answers `text/event-stream` with `no-transform` and `X-Accel-Buffering: no` so proxies cannot buffer away the incremental delivery. The body is validated *before* any stream is opened, so an invalid request still gets a normal JSON 400.
- **Cancellation** ties an `AbortController` to client disconnect: the provider request is abandoned, no further tool invocation starts, and nothing is persisted — an abandoned run never reaches a terminal event.
- **Parity** with `POST /chat` on validation, identity and persistence, via the extracted `validateChatRequest` and `saveChatConversation` helpers that both routes now share. A persistence failure still reaches the completion event.
- Every provider is streamable: one without native streaming is served by the `LLMProvider` fallback as a single fragment, so clients need no second code path.

### `POST /chat` is unchanged

Its request, response and behaviour are identical, and its **36 existing router tests plus 13 plugin tests pass unmodified**. Note a deliberate deviation from task 2.6's literal "additive diff only" wording: rather than duplicating ~70 lines of validation and persistence, both were extracted verbatim into shared helpers that `POST /chat` now calls — the same reuse principle task 2.1 asks for on `QueryProcessor`. A parameterised test runs all eight invalid payloads against **both** endpoints and asserts identical status and body, so the two cannot drift.

### Verification

| Check | Result |
| --- | --- |
| `yarn dedupe --check` | clean (no dependencies added) |
| `yarn tsc:full` | passes |
| `CI=true yarn test` | 56 suites, 642 tests, all green |
| `openspec validate add-mcp-chat-prompt-page --strict` | valid |
| Provider modules touched | **0** of 9 |
| `plugins/mcp-chat/src/**` touched | **0 files** |

New tests: 6 on `streamQuery` (streamed reply, single-fragment fallback, tool invoked mid-run, tool failure, abort, native-MCP replay) and 15 on the route, including a real socket-disconnect test that asserts the abort propagates and nothing is stored.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
