### PR TITLE
fix(aws): build pgvector image from bitnamilegacy postgresql

### DIFF
--- a/workspaces/aws/containers/pgvector/Dockerfile
+++ b/workspaces/aws/containers/pgvector/Dockerfile
@@ -1,4 +1,4 @@
-ARG POSTGRES_VERSION="latest"
+ARG POSTGRES_VERSION="17.6.0"
 FROM docker.io/bitnamilegacy/postgresql:${POSTGRES_VERSION}
 
 USER root

--- a/workspaces/aws/containers/pgvector/Dockerfile
+++ b/workspaces/aws/containers/pgvector/Dockerfile
@@ -1,5 +1,5 @@
-ARG POSTGRES_VERSION="18.3.0"
-FROM public.ecr.aws/bitnami/postgresql:${POSTGRES_VERSION}
+ARG POSTGRES_VERSION="latest"
+FROM docker.io/bitnamilegacy/postgresql:${POSTGRES_VERSION}
 
 USER root
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`workspaces/aws/containers/pgvector` built from `public.ecr.aws/bitnami/postgresql:18.3.0`, a tag that does not exist since Bitnami archived its public catalog. The image build failed, so the `postgres` service of `workspaces/aws/docker-compose.yaml` never came up and no data could be persisted.

The base image is now the archived `docker.io/bitnamilegacy/postgresql`, pinned to `17.6.0` — the newest tag that archive actually publishes. The `bitnamilegacy` namespace is frozen and never got an 18.x tag (`docker manifest inspect docker.io/bitnamilegacy/postgresql:18.3.0` → `not found`); its `latest` still resolves to 17.5, hence the explicit pin. The `POSTGRES_VERSION` build arg remains overridable via `--build-arg`.

Verified locally: `docker build containers/pgvector` succeeds, the container starts on PostgreSQL 17.6, and the init scripts create `vector 0.8.2` and `uuid-ossp 1.1`.

If PostgreSQL 18.x is required, the base image has to leave the Bitnami family (`docker.io/postgres:18.3` or `docker.io/pgvector/pgvector:pg18`), which also changes the entrypoint/init-script conventions and the data directory.

Note for a follow-up (out of scope here): the compose volume mounts `/var/lib/postgresql/data`, but the Bitnami image stores its cluster in `/bitnami/postgresql/data` — that path does not exist in the image, so data still won't survive a container recreate until the mount is corrected.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets)) — n/a, no published package is affected
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes — n/a, container build verified manually
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
