### PR TITLE
OSS-11 feat(mcp-chat): Assistant UI conversation surface

### DIFF
--- a/openspec/changes/add-mcp-chat-prompt-page/tasks.md
+++ b/openspec/changes/add-mcp-chat-prompt-page/tasks.md
@@ -133,25 +133,25 @@ transport error handling_ (state layer).
 Covers _Prompt submission_, _Run lifecycle and streamed completion_, _Provider and
 transport error handling_ (presentation).
 
-- [ ] 5.1 Build the composer from `ComposerPrimitive` with multi-line input,
+- [x] 5.1 Build the composer from `ComposerPrimitive` with multi-line input,
       submit-on-Enter and newline-on-Shift-Enter, styled with a CSS module over
       BUI tokens. Verify with a test driving `screen` queries and `findBy*` —
       scenario _A prompt is submitted_.
-- [ ] 5.2 Build the message list and viewport from `ThreadPrimitive` and
+- [x] 5.2 Build the message list and viewport from `ThreadPrimitive` and
       `MessagePrimitive`, rendering assistant text as markdown, including while it
       is still growing. Verify with tests — scenarios _A reply renders
       incrementally_ and _A run completes successfully_.
-- [ ] 5.3 Render the running indicator and the cancel control from the runtime's
+- [x] 5.3 Render the running indicator and the cancel control from the runtime's
       running state. Verify with a test asserting both appear while a run is in
       flight and clear afterwards — scenario _A run is in progress_.
-- [ ] 5.4 Render run failures as an error distinct from assistant content, with a
+- [x] 5.4 Render run failures as an error distinct from assistant content, with a
       retry control, preserving any partial text. Verify with tests — scenarios
       _The chat provider returns an error_, _The backend is unreachable_, _A run
       fails after partial output_.
-- [ ] 5.5 Verify a non-streaming provider's single-fragment reply renders and
+- [x] 5.5 Verify a non-streaming provider's single-fragment reply renders and
       completes normally, with a test — scenario _A non-streaming provider is
       used_.
-- [ ] 5.6 Confirm no file added under `src/components/PromptPage` imports
+- [x] 5.6 Confirm no file added under `src/components/PromptPage` imports
       `@backstage/core-components`, `@mui/material` or `@mui/icons-material`.
       Verify with `grep` over the new directory and with `yarn lint --fix`
       reporting clean.

--- a/workspaces/mcp-chat/.changeset/mcp-chat-conversation-surface.md
+++ b/workspaces/mcp-chat/.changeset/mcp-chat-conversation-surface.md
@@ -1,0 +1,25 @@
+---
+'@alithya-oss/backstage-plugin-mcp-chat': minor
+---
+
+The Assistant UI prompt page at `/mcp-chat-prompt` now has a working
+conversation surface, built on `@assistant-ui/react` primitives and styled with
+CSS modules over Backstage UI design tokens.
+
+The composer accepts multi-line text, submits on Enter and inserts a newline on
+Shift+Enter. A blank or whitespace-only prompt starts no run. The assistant reply
+is rendered as markdown while it is still growing, so text is readable before the
+run ends — and a provider without native streaming, whose whole reply arrives as
+one fragment, takes exactly the same path.
+
+While a run is in flight the page says the assistant is working and offers a
+cancel control in place of the send control; both follow the runtime's state, so
+they clear when the run completes, fails or is cancelled. A failed run is
+reported as an alert beside the conversation rather than as assistant content,
+wording an unreachable backend differently from a provider failure, and offers a
+retry that re-runs the last prompt. Text that had already arrived when a run
+failed is kept and labelled as interrupted instead of being retracted or passed
+off as a complete answer.
+
+MCP tool call rendering and the reduced side panel land in follow-ups; the
+existing `/mcp-chat` page is unchanged.

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/MarkdownText.module.css
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/MarkdownText.module.css
@@ -1,0 +1,123 @@
+.markdown {
+  color: var(--bui-fg-primary);
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-3);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.markdown > :first-child {
+  margin-top: 0;
+}
+
+.markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+  margin: var(--bui-space-4) 0 var(--bui-space-2);
+  font-weight: var(--bui-font-weight-bold);
+  line-height: 1.3;
+}
+
+.markdown h1 {
+  font-size: var(--bui-font-size-6);
+}
+
+.markdown h2 {
+  font-size: var(--bui-font-size-5);
+}
+
+.markdown h3 {
+  font-size: var(--bui-font-size-4);
+}
+
+.markdown p {
+  margin: var(--bui-space-2) 0;
+}
+
+.markdown ul,
+.markdown ol {
+  margin: var(--bui-space-2) 0;
+  padding-left: var(--bui-space-6);
+}
+
+.markdown li {
+  margin: var(--bui-space-1) 0;
+}
+
+.markdown a {
+  color: var(--bui-fg-info);
+  text-decoration: none;
+}
+
+.markdown a:hover,
+.markdown a:focus-visible {
+  text-decoration: underline;
+}
+
+.markdown blockquote {
+  margin: var(--bui-space-3) 0;
+  padding: var(--bui-space-2) var(--bui-space-4);
+  border-left: 4px solid var(--bui-border-2);
+  border-radius: var(--bui-radius-2);
+  background-color: var(--bui-bg-neutral-2);
+  color: var(--bui-fg-secondary);
+}
+
+.markdown code {
+  padding: 2px var(--bui-space-1);
+  border-radius: var(--bui-radius-1);
+  background-color: var(--bui-bg-neutral-2);
+  font-family: var(--bui-font-monospace);
+  font-size: var(--bui-font-size-2);
+}
+
+.markdown pre {
+  margin: var(--bui-space-3) 0;
+  padding: var(--bui-space-3);
+  overflow: auto;
+  border: 1px solid var(--bui-border-1);
+  border-radius: var(--bui-radius-2);
+  background-color: var(--bui-bg-neutral-2);
+  font-family: var(--bui-font-monospace);
+  font-size: var(--bui-font-size-2);
+}
+
+.markdown pre code {
+  padding: 0;
+  background-color: transparent;
+}
+
+.markdown table {
+  margin: var(--bui-space-3) 0;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.markdown th,
+.markdown td {
+  padding: var(--bui-space-1) var(--bui-space-2);
+  border: 1px solid var(--bui-border-1);
+  text-align: left;
+}
+
+.markdown th {
+  background-color: var(--bui-bg-neutral-2);
+  font-weight: var(--bui-font-weight-bold);
+}
+
+.markdown hr {
+  margin: var(--bui-space-4) 0;
+  border: none;
+  border-top: 1px solid var(--bui-border-1);
+}
+
+.markdown img {
+  max-width: 100%;
+}

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/MarkdownText.tsx
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/MarkdownText.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ReactMarkdown from 'react-markdown';
+import type { TextMessagePartComponent } from '@assistant-ui/react';
+import styles from './MarkdownText.module.css';
+
+/**
+ * Renders a `text` message part as markdown.
+ *
+ * The same component renders a growing text part and a finished one: the text a
+ * part holds at any moment is parsed as markdown, so formatting appears as soon
+ * as the fragments that complete a construct have arrived rather than only at
+ * the end of the run. A provider that delivers its whole reply in one fragment
+ * therefore takes exactly this path too — there is no separate code path for
+ * non-streaming providers.
+ *
+ * `data-status` carries the part's own status so styling can mark text that is
+ * still arriving without a second component.
+ */
+export const MarkdownText: TextMessagePartComponent = ({ text, status }) => (
+  <div className={styles.markdown} data-status={status.type}>
+    <ReactMarkdown>{text}</ReactMarkdown>
+  </div>
+);

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptComposer.module.css
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptComposer.module.css
@@ -1,0 +1,78 @@
+.root {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: var(--bui-space-2);
+  padding: var(--bui-space-2);
+  border: 1px solid var(--bui-border-1);
+  border-radius: var(--bui-radius-3);
+  background-color: var(--bui-bg-neutral-1);
+}
+
+.input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: var(--bui-space-2);
+  border: none;
+  background-color: transparent;
+  color: var(--bui-fg-primary);
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-3);
+  line-height: 1.5;
+  resize: none;
+}
+
+.input::placeholder {
+  color: var(--bui-fg-secondary);
+}
+
+.input:focus-visible {
+  outline: none;
+}
+
+.root:focus-within {
+  outline: 2px solid var(--bui-ring);
+  outline-offset: -1px;
+}
+
+.actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--bui-space-1);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--bui-space-8);
+  height: var(--bui-space-8);
+  padding: 0;
+  border: none;
+  border-radius: var(--bui-radius-full);
+  background-color: var(--bui-bg-solid);
+  color: var(--bui-fg-solid);
+  cursor: pointer;
+}
+
+.button:hover:not(:disabled) {
+  background-color: var(--bui-bg-solid-hover);
+}
+
+.button:disabled {
+  background-color: var(--bui-bg-solid-disabled);
+  color: var(--bui-fg-solid-disabled);
+  cursor: not-allowed;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--bui-ring);
+  outline-offset: 2px;
+}
+
+.icon {
+  width: var(--bui-space-5);
+  height: var(--bui-space-5);
+}

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptComposer.tsx
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptComposer.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AuiIf, ComposerPrimitive } from '@assistant-ui/react';
+import { RiSendPlane2Line, RiStopCircleLine } from '@remixicon/react';
+import styles from './PromptComposer.module.css';
+
+/**
+ * The prompt composer.
+ *
+ * `ComposerPrimitive.Input` is a textarea that grows with its content, so a
+ * multi-line prompt needs no mode switch. `submitMode="enter"` is passed
+ * explicitly rather than left to the default: Enter submits and Shift+Enter
+ * inserts a newline, and stating it keeps that contract from moving with the
+ * library's default.
+ *
+ * Send and cancel occupy the same slot, swapped on the runtime's running state.
+ * That is what makes the cancel control appear exactly while a run is in flight
+ * and disappear once it ends, without the page tracking that itself.
+ */
+export const PromptComposer = () => (
+  <ComposerPrimitive.Root className={styles.root}>
+    <ComposerPrimitive.Input
+      className={styles.input}
+      submitMode="enter"
+      minRows={1}
+      maxRows={12}
+      placeholder="Ask about your MCP servers…"
+      aria-label="Prompt"
+    />
+    <div className={styles.actions}>
+      <AuiIf condition={state => !state.thread.isRunning}>
+        <ComposerPrimitive.Send
+          className={styles.button}
+          aria-label="Send prompt"
+        >
+          <RiSendPlane2Line aria-hidden className={styles.icon} />
+        </ComposerPrimitive.Send>
+      </AuiIf>
+      <AuiIf condition={state => state.thread.isRunning}>
+        <ComposerPrimitive.Cancel
+          className={styles.button}
+          aria-label="Cancel run"
+        >
+          <RiStopCircleLine aria-hidden className={styles.icon} />
+        </ComposerPrimitive.Cancel>
+      </AuiIf>
+    </div>
+  </ComposerPrimitive.Root>
+);

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptMessage.module.css
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptMessage.module.css
@@ -1,0 +1,43 @@
+.userRoot {
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--bui-space-2) 0;
+}
+
+.userBubble {
+  max-width: 80%;
+  padding: var(--bui-space-2) var(--bui-space-4);
+  border: 1px solid var(--bui-border-1);
+  border-radius: var(--bui-radius-3);
+  background-color: var(--bui-bg-neutral-2);
+}
+
+.assistantRoot {
+  display: flex;
+  justify-content: flex-start;
+  padding: var(--bui-space-2) 0;
+}
+
+.assistantBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bui-space-2);
+  max-width: 100%;
+  min-width: 0;
+}
+
+.interrupted {
+  display: flex;
+  align-items: center;
+  gap: var(--bui-space-1);
+  margin: 0;
+  color: var(--bui-fg-warning);
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-2);
+}
+
+.interruptedIcon {
+  flex: 0 0 auto;
+  width: var(--bui-space-4);
+  height: var(--bui-space-4);
+}

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptMessage.tsx
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptMessage.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AuiIf, MessagePrimitive } from '@assistant-ui/react';
+import { RiAlertLine } from '@remixicon/react';
+import { MarkdownText } from './MarkdownText';
+import styles from './PromptMessage.module.css';
+
+/**
+ * Part renderers shared by both roles.
+ *
+ * Declared once at module scope so the object identity is stable across
+ * renders: `MessagePrimitive.Parts` treats a new `components` object as a
+ * change, and a growing text part re-renders often enough for that to matter.
+ *
+ * Only `Text` is overridden here. Tool-call parts keep the library's default
+ * until the catch-all tool renderer of the following task group replaces it, so
+ * an invocation is never dropped from the turn in the meantime.
+ */
+const PART_COMPONENTS = { Text: MarkdownText };
+
+/**
+ * A user turn.
+ */
+export const PromptUserMessage = () => (
+  <MessagePrimitive.Root className={styles.userRoot}>
+    <div className={styles.userBubble}>
+      <MessagePrimitive.Parts components={PART_COMPONENTS} />
+    </div>
+  </MessagePrimitive.Root>
+);
+
+/**
+ * An assistant turn.
+ *
+ * The text is rendered by the same markdown component whether it is still
+ * growing or finished, so formatting becomes readable before the run ends.
+ *
+ * A turn whose run did not reach completion keeps whatever text had arrived and
+ * is labelled as interrupted rather than being retracted or presented as a
+ * finished answer. The label is driven by the message's own status, so it
+ * follows the run without the page tracking it.
+ */
+export const PromptAssistantMessage = () => (
+  <MessagePrimitive.Root className={styles.assistantRoot}>
+    <div className={styles.assistantBody}>
+      <MessagePrimitive.Parts components={PART_COMPONENTS} />
+      <AuiIf condition={state => state.message.status?.type === 'incomplete'}>
+        <p className={styles.interrupted}>
+          <RiAlertLine aria-hidden className={styles.interruptedIcon} />
+          This answer was interrupted and is incomplete.
+        </p>
+      </AuiIf>
+    </div>
+  </MessagePrimitive.Root>
+);

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptPageContent.module.css
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptPageContent.module.css
@@ -12,13 +12,6 @@
 .heading {
   margin: 0;
   color: var(--bui-fg-primary);
-}
-
-.thread {
-  display: flex;
-  flex: 1;
-  min-height: 0;
-  flex-direction: column;
-  gap: var(--bui-space-2);
-  color: var(--bui-fg-secondary);
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-6);
 }

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptPageContent.tsx
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptPageContent.tsx
@@ -19,6 +19,7 @@ import {
   useExternalStoreRuntime,
 } from '@assistant-ui/react';
 import { usePromptThread } from './usePromptThread';
+import { PromptThread } from './PromptThread';
 import styles from './PromptPageContent.module.css';
 
 /**
@@ -30,20 +31,22 @@ import styles from './PromptPageContent.module.css';
  * truth: selecting a stored conversation replaces the list without the runtime
  * having to import a message repository.
  *
- * The thread primitives, tool call rendering and reduced side panel are added by
- * the following task groups of the `add-mcp-chat-prompt-page` change.
+ * The run failure is the one piece of state the surface receives as a prop
+ * rather than reading from the runtime: it is the page's, not a message's, which
+ * is what keeps a failure from being rendered as assistant content.
+ *
+ * The tool call rendering and the reduced side panel are added by the following
+ * task groups of the `add-mcp-chat-prompt-page` change.
  */
 export const PromptPageContent = () => {
-  const { adapter } = usePromptThread();
+  const { adapter, error, retry } = usePromptThread();
   const runtime = useExternalStoreRuntime(adapter);
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
       <div className={styles.root}>
         <h1 className={styles.heading}>MCP Prompt</h1>
-        <div className={styles.thread}>
-          <p>The conversation surface is not wired up yet.</p>
-        </div>
+        <PromptThread error={error} onRetry={retry} />
       </div>
     </AssistantRuntimeProvider>
   );

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptThread.module.css
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptThread.module.css
@@ -1,0 +1,44 @@
+.root {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--bui-space-3);
+  min-height: 0;
+}
+
+.viewport {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  padding-right: var(--bui-space-2);
+  overflow-y: auto;
+  scrollbar-color: var(--bui-scrollbar-thumb) var(--bui-scrollbar);
+}
+
+.empty {
+  margin: auto 0;
+  color: var(--bui-fg-secondary);
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-3);
+  text-align: center;
+}
+
+.running {
+  display: flex;
+  align-items: center;
+  gap: var(--bui-space-2);
+  margin: var(--bui-space-2) 0;
+  color: var(--bui-fg-secondary);
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-2);
+}
+
+.spinner {
+  flex: 0 0 auto;
+  width: var(--bui-space-3);
+  height: var(--bui-space-3);
+  border-radius: var(--bui-radius-full);
+  background-color: var(--bui-fg-secondary);
+  animation: var(--bui-animate-pulse);
+}

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptThread.test.tsx
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptThread.test.tsx
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { mcpChatApiRef } from '../../api';
+import type { ChatStreamEvent } from '../../types';
+import { PromptPageContent } from './PromptPageContent';
+
+/**
+ * A stream the test drives event by event, so the surface can be inspected
+ * between two fragments rather than only once the run is over.
+ */
+function createStream() {
+  const queue: ChatStreamEvent[] = [];
+  const waiters: Array<() => void> = [];
+  let closed = false;
+  let failure: unknown;
+
+  const nudge = () => {
+    while (waiters.length > 0) {
+      (waiters.shift() as () => void)();
+    }
+  };
+
+  return {
+    push(event: ChatStreamEvent) {
+      queue.push(event);
+      nudge();
+    },
+    close() {
+      closed = true;
+      nudge();
+    },
+    fail(error: unknown) {
+      failure = error;
+      closed = true;
+      nudge();
+    },
+    iterable: {
+      async *[Symbol.asyncIterator]() {
+        while (true) {
+          while (queue.length > 0) {
+            yield queue.shift() as ChatStreamEvent;
+          }
+          if (failure) {
+            throw failure;
+          }
+          if (closed) {
+            return;
+          }
+          await new Promise<void>(resolve => {
+            waiters.push(resolve);
+          });
+        }
+      },
+    } as AsyncIterable<ChatStreamEvent>,
+  };
+}
+
+function renderPromptPage(streamChatMessage: jest.Mock) {
+  const mcpChatApi = {
+    sendChatMessage: jest.fn(),
+    streamChatMessage,
+    getMCPServerStatus: jest.fn(),
+    getAvailableTools: jest.fn(),
+    getProviderStatus: jest.fn(),
+    getConversations: jest.fn(),
+    getConversationById: jest.fn(),
+    deleteConversation: jest.fn(),
+    toggleConversationStar: jest.fn(),
+  };
+
+  render(
+    <TestApiProvider apis={[[mcpChatApiRef, mcpChatApi]]}>
+      <PromptPageContent />
+    </TestApiProvider>,
+  );
+
+  return { mcpChatApi };
+}
+
+/** Types into the composer and submits with Enter. */
+async function submitPrompt(text: string) {
+  const input = await screen.findByRole('textbox', { name: 'Prompt' });
+  await act(async () => {
+    fireEvent.change(input, { target: { value: text } });
+  });
+  await act(async () => {
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+  });
+  return input as HTMLTextAreaElement;
+}
+
+/** Applies stream activity and lets the run loop drain it. */
+async function flush(apply: () => void) {
+  await act(async () => {
+    apply();
+  });
+}
+
+describe('the prompt page conversation surface', () => {
+  it('submits a prompt on Enter, keeps Shift+Enter for a newline, and refuses a blank prompt', async () => {
+    const stream = createStream();
+    const streamChatMessage = jest.fn().mockReturnValue(stream.iterable);
+    renderPromptPage(streamChatMessage);
+
+    const input = await screen.findByRole('textbox', { name: 'Prompt' });
+
+    // A whitespace-only prompt starts nothing.
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '   ' } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+    expect(streamChatMessage).not.toHaveBeenCalled();
+
+    // Shift+Enter is a newline, not a submission: the composer keeps its text
+    // and no run starts.
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'first line' } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(input, {
+        key: 'Enter',
+        code: 'Enter',
+        shiftKey: true,
+      });
+    });
+    expect(streamChatMessage).not.toHaveBeenCalled();
+    expect(input).toHaveValue('first line');
+
+    await act(async () => {
+      fireEvent.change(input, {
+        target: { value: 'first line\nlist my components' },
+      });
+    });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    expect(
+      await screen.findByText(/first line\s*list my components/),
+    ).toBeInTheDocument();
+    expect(input).toHaveValue('');
+    expect(streamChatMessage).toHaveBeenCalledTimes(1);
+    expect(streamChatMessage.mock.calls[0][0]).toEqual([
+      { role: 'user', content: 'first line\nlist my components' },
+    ]);
+  });
+
+  it('grows the assistant turn fragment by fragment while offering a cancel control, then renders the completed markdown', async () => {
+    const stream = createStream();
+    const streamChatMessage = jest.fn().mockReturnValue(stream.iterable);
+    renderPromptPage(streamChatMessage);
+
+    await submitPrompt('list my components');
+
+    // A run is in progress: the page says so and offers a way to cancel, before
+    // any fragment has arrived.
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'The assistant is working',
+    );
+    expect(
+      await screen.findByRole('button', { name: 'Cancel run' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Send prompt' }),
+    ).not.toBeInTheDocument();
+
+    await flush(() => stream.push({ type: 'text', text: '## Components\n\n' }));
+
+    // The markdown is already formatted while the reply is still growing.
+    expect(
+      await screen.findByRole('heading', { level: 2, name: 'Components' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    await flush(() =>
+      stream.push({ type: 'text', text: '- **catalog** is ready' }),
+    );
+
+    const item = await screen.findByRole('listitem');
+    expect(item).toHaveTextContent('catalog is ready');
+    expect(item.querySelector('strong')).toHaveTextContent('catalog');
+    // Still marked as running between the last fragment and the terminal event.
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    await flush(() => {
+      stream.push({ type: 'complete', toolsUsed: [], conversationId: 'c-1' });
+      stream.close();
+    });
+
+    // The run indication clears and the composer offers to send again.
+    expect(
+      await screen.findByRole('button', { name: 'Send prompt' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Cancel run' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Components' }),
+    ).toBeInTheDocument();
+    // A completed turn carries no interruption notice.
+    expect(screen.queryByText(/interrupted/i)).not.toBeInTheDocument();
+  });
+
+  it("renders and completes a non-streaming provider's single-fragment reply through the same path", async () => {
+    const stream = createStream();
+    const streamChatMessage = jest.fn().mockReturnValue(stream.iterable);
+    renderPromptPage(streamChatMessage);
+
+    await submitPrompt('how many components do I own?');
+
+    await flush(() => {
+      // The base-class fallback delivers the whole reply as one fragment,
+      // immediately followed by the terminal event.
+      stream.push({
+        type: 'text',
+        text: 'You own **three** components.',
+      });
+      stream.push({ type: 'complete', toolsUsed: [] });
+      stream.close();
+    });
+
+    // The reply is a single paragraph split across a bold run, so the assertion
+    // reads the paragraph's whole text rather than one of its text nodes.
+    const reply = await screen.findByText(/You own/);
+    expect(reply).toHaveTextContent('You own three components.');
+    expect(reply.querySelector('strong')).toHaveTextContent('three');
+    expect(
+      await screen.findByRole('button', { name: 'Send prompt' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText(/interrupted/i)).not.toBeInTheDocument();
+  });
+
+  it('surfaces a provider failure as an error outside the conversation and retries into an answer', async () => {
+    const failing = createStream();
+    const succeeding = createStream();
+    const streamChatMessage = jest
+      .fn()
+      .mockReturnValueOnce(failing.iterable)
+      .mockReturnValueOnce(succeeding.iterable);
+    renderPromptPage(streamChatMessage);
+
+    await submitPrompt('list my components');
+
+    await flush(() => {
+      failing.push({ type: 'error', message: 'model quota exceeded' });
+      failing.close();
+    });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('The chat provider could not answer.');
+    expect(alert).toHaveTextContent('model quota exceeded');
+    // The failure is not assistant content and the page is not stuck running.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Send prompt' }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    });
+
+    await flush(() => {
+      succeeding.push({ type: 'text', text: 'Two components.' });
+      succeeding.push({ type: 'complete', toolsUsed: [] });
+      succeeding.close();
+    });
+
+    expect(await screen.findByText('Two components.')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByText('list my components')).toBeInTheDocument();
+    expect(streamChatMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports an unreachable backend and keeps partial text marked interrupted when a run fails after output', async () => {
+    const unreachable = createStream();
+    const interrupted = createStream();
+    const streamChatMessage = jest
+      .fn()
+      .mockReturnValueOnce(unreachable.iterable)
+      .mockReturnValueOnce(interrupted.iterable);
+    renderPromptPage(streamChatMessage);
+
+    await submitPrompt('list my components');
+
+    await flush(() => unreachable.fail(new Error('Failed to fetch')));
+
+    const transportAlert = await screen.findByRole('alert');
+    expect(transportAlert).toHaveTextContent(
+      'The chat service is unavailable.',
+    );
+    expect(transportAlert).toHaveTextContent('Failed to fetch');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    // Retry, this time failing only after some text has been rendered.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    });
+
+    await flush(() =>
+      interrupted.push({ type: 'text', text: 'Reading the catalog' }),
+    );
+    expect(await screen.findByText('Reading the catalog')).toBeInTheDocument();
+
+    await flush(() => {
+      interrupted.push({ type: 'error', message: 'upstream timeout' });
+      interrupted.close();
+    });
+
+    // The partial text survives, marked as interrupted rather than passed off
+    // as a finished answer, and the failure is reported next to it.
+    expect(
+      await screen.findByText(/interrupted and is incomplete/),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Reading the catalog')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('upstream timeout');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('clears the run indication and drops the partial turn when the run is cancelled', async () => {
+    const stream = createStream();
+    const streamChatMessage = jest.fn().mockReturnValue(stream.iterable);
+    renderPromptPage(streamChatMessage);
+
+    await submitPrompt('list my components');
+
+    await flush(() => stream.push({ type: 'text', text: 'Reading the' }));
+    expect(await screen.findByText('Reading the')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel run' }));
+    });
+
+    // No partial turn is left behind marked running, and the composer accepts a
+    // prompt again.
+    expect(
+      await screen.findByRole('button', { name: 'Send prompt' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByText('Reading the')).not.toBeInTheDocument();
+    expect(screen.getByText('list my components')).toBeInTheDocument();
+  });
+});

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptThread.tsx
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/PromptThread.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from 'react';
+import { AuiIf, ThreadPrimitive } from '@assistant-ui/react';
+import type { MessageState } from '@assistant-ui/react';
+import { PromptComposer } from './PromptComposer';
+import { PromptAssistantMessage, PromptUserMessage } from './PromptMessage';
+import { RunError } from './RunError';
+import type { PromptThreadError } from './promptThreadTypes';
+import styles from './PromptThread.module.css';
+
+/**
+ * Picks the renderer for one turn.
+ *
+ * Declared at module scope because `ThreadPrimitive.Messages` compares its
+ * children by identity: an inline function would re-create the whole list on
+ * every fragment of a streamed reply.
+ */
+const renderMessage = ({ message }: { message: MessageState }): ReactNode =>
+  message.role === 'user' ? <PromptUserMessage /> : <PromptAssistantMessage />;
+
+/**
+ * Props of {@link PromptThread}.
+ */
+export interface PromptThreadProps {
+  /** The failure of the last run, or `undefined` while none is outstanding. */
+  error?: PromptThreadError | undefined;
+  /** Re-runs the last user turn. */
+  onRetry: () => void;
+}
+
+/**
+ * The conversation surface: viewport, turns, run indication and composer.
+ *
+ * Everything about the run comes from the runtime rather than from props. The
+ * turns are read through `ThreadPrimitive.Messages`, and the working indication
+ * is gated on `thread.isRunning`, so it appears the moment a run starts — before
+ * any fragment has arrived — and clears when the run completes, fails or is
+ * cancelled.
+ *
+ * The failure is the one thing passed in: it belongs to the page's own state,
+ * not to a message, which is exactly why it renders outside the conversation.
+ */
+export const PromptThread = ({ error, onRetry }: PromptThreadProps) => (
+  <ThreadPrimitive.Root className={styles.root}>
+    <ThreadPrimitive.Viewport className={styles.viewport}>
+      <AuiIf condition={state => state.thread.isEmpty}>
+        <p className={styles.empty}>
+          Ask a question to start a conversation with your MCP servers.
+        </p>
+      </AuiIf>
+      <ThreadPrimitive.Messages>{renderMessage}</ThreadPrimitive.Messages>
+      <AuiIf condition={state => state.thread.isRunning}>
+        <p className={styles.running} role="status">
+          <span aria-hidden className={styles.spinner} />
+          The assistant is working…
+        </p>
+      </AuiIf>
+    </ThreadPrimitive.Viewport>
+    {error ? <RunError error={error} onRetry={onRetry} /> : null}
+    <PromptComposer />
+  </ThreadPrimitive.Root>
+);

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/RunError.module.css
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/RunError.module.css
@@ -1,0 +1,68 @@
+.root {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: flex-start;
+  gap: var(--bui-space-3);
+  padding: var(--bui-space-3);
+  border: 1px solid var(--bui-border-danger);
+  border-radius: var(--bui-radius-2);
+  background-color: var(--bui-bg-danger);
+  color: var(--bui-fg-danger-on-bg);
+}
+
+.icon {
+  flex: 0 0 auto;
+  width: var(--bui-space-5);
+  height: var(--bui-space-5);
+}
+
+.body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--bui-space-1);
+  min-width: 0;
+}
+
+.headline {
+  margin: 0;
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-3);
+  font-weight: var(--bui-font-weight-bold);
+}
+
+.detail {
+  margin: 0;
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-2);
+  overflow-wrap: anywhere;
+}
+
+.retry {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--bui-space-1);
+  padding: var(--bui-space-1) var(--bui-space-3);
+  border: 1px solid var(--bui-border-danger);
+  border-radius: var(--bui-radius-2);
+  background-color: transparent;
+  color: inherit;
+  font-family: var(--bui-font-regular);
+  font-size: var(--bui-font-size-2);
+  cursor: pointer;
+}
+
+.retry:hover {
+  background-color: var(--bui-bg-neutral-1-hover);
+}
+
+.retry:focus-visible {
+  outline: 2px solid var(--bui-ring);
+  outline-offset: 2px;
+}
+
+.retryIcon {
+  width: var(--bui-space-4);
+  height: var(--bui-space-4);
+}

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/RunError.tsx
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/components/PromptPage/RunError.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The Alithya Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  RiCloudOffLine,
+  RiErrorWarningLine,
+  RiRefreshLine,
+} from '@remixicon/react';
+import type { PromptThreadError } from './promptThreadTypes';
+import styles from './RunError.module.css';
+
+/**
+ * Props of {@link RunError}.
+ */
+export interface RunErrorProps {
+  /** The failure of the last run. */
+  error: PromptThreadError;
+  /** Re-runs the last user turn. */
+  onRetry: () => void;
+}
+
+const HEADLINE: Record<PromptThreadError['kind'], string> = {
+  transport: 'The chat service is unavailable.',
+  provider: 'The chat provider could not answer.',
+};
+
+/**
+ * A failed run, rendered outside the conversation.
+ *
+ * The failure is deliberately not assistant content: it sits in its own alert
+ * next to the conversation, so a partial answer above it stays visible and
+ * marked as interrupted instead of being replaced or passed off as complete.
+ *
+ * `transport` and `provider` are worded differently because they are different
+ * problems for the reader — one is the plugin's backend being out of reach, the
+ * other is the provider rejecting the run. Retry re-runs the last user turn
+ * either way.
+ */
+export const RunError = ({ error, onRetry }: RunErrorProps) => {
+  const Icon = error.kind === 'transport' ? RiCloudOffLine : RiErrorWarningLine;
+
+  return (
+    <div className={styles.root} role="alert">
+      <Icon aria-hidden className={styles.icon} />
+      <div className={styles.body}>
+        <p className={styles.headline}>{HEADLINE[error.kind]}</p>
+        <p className={styles.detail}>{error.message}</p>
+      </div>
+      <button type="button" className={styles.retry} onClick={onRetry}>
+        <RiRefreshLine aria-hidden className={styles.retryIcon} />
+        Retry
+      </button>
+    </div>
+  );
+};

--- a/workspaces/mcp-chat/plugins/mcp-chat/src/setupTests.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat/src/setupTests.ts
@@ -15,3 +15,30 @@
  */
 
 import '@testing-library/jest-dom';
+
+/**
+ * jsdom ships no `ResizeObserver`, and the Assistant UI thread viewport observes
+ * its content size to decide when to follow the bottom of the conversation. A
+ * no-op observer is enough: the tests assert what is rendered, never how far the
+ * viewport scrolled.
+ */
+if (!('ResizeObserver' in globalThis)) {
+  class ResizeObserverStub implements ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+    ResizeObserverStub;
+}
+
+/**
+ * jsdom implements no scrolling either, and the same viewport calls `scrollTo`
+ * from an animation frame — where a throwing call surfaces as an unhandled
+ * exception rather than a failed assertion. A no-op keeps that noise out of runs
+ * that are not about scroll position.
+ */
+if (typeof Element !== 'undefined' && !Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = () => {};
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Group **5** of the `add-mcp-chat-prompt-page` OpenSpec change — the presentation
layer of _Prompt submission_, _Run lifecycle and streamed completion_ and
_Provider and transport error handling_. Builds on group 4 (#242), which landed
the streaming client and the external store adapter.

The prompt page at `/mcp-chat-prompt` now has a working conversation surface,
built on `@assistant-ui/react` primitives and styled with CSS modules over
Backstage UI design tokens. No `@backstage/core-components`, no `@mui/material`
and no `@mui/icons-material` under `src/components/PromptPage` — icons come from
`@remixicon/react`.

- **Composer** (`ComposerPrimitive`): multi-line, Enter submits, Shift+Enter
  inserts a newline, and a whitespace-only prompt starts nothing. Send and cancel
  share one slot, swapped on the runtime's running state, so the cancel control
  exists exactly while a run is in flight.
- **Messages and viewport** (`ThreadPrimitive`, `MessagePrimitive`): assistant
  text renders through `react-markdown` **while it is still growing**, so
  formatting is readable before the run ends. A non-streaming provider's
  single-fragment reply takes that same path — there is no second code path for
  it.
- **Run failures** render as an alert beside the conversation rather than as
  assistant content, wording an unreachable backend differently from a provider
  failure, with a retry that re-runs the last prompt. Text that had already
  arrived is kept and labelled interrupted, driven by the message's own status.
- `setupTests` stubs `ResizeObserver` and `Element.prototype.scrollTo`, neither of
  which jsdom ships and both of which the thread viewport uses from an animation
  frame, where a throwing call surfaces as an unhandled exception instead of a
  failed assertion.

Six tests drive the surface through the real runtime over a stream the test
advances event by event, so a turn is inspected _between_ two fragments rather
than only after the run. They cover the scenarios _A prompt is submitted_, _A
reply renders incrementally_, _A run is in progress_, _A run completes
successfully_, _A non-streaming provider is used_, _A run is cancelled_, _The chat
provider returns an error_, _The backend is unreachable_, _A run fails after
partial output_ and _A retry succeeds after a failure_.

MCP tool call rendering (group 6) and the reduced side panel (group 8) land in
follow-ups. `/mcp-chat`, `POST /chat`, `sendChatMessage`, `ChatContainer/**`,
`RightPane/**` and `ChatPage/**` are untouched.

Verified locally: `CI=true yarn test` (60 suites, 675 tests), `yarn tsc`,
`yarn tsc:full`, `yarn prettier:check`, `yarn lint:all`, `yarn dedupe --check`,
`yarn fix --check`, `yarn build:api-reports:only --ci` (no public API change) and
`openspec validate add-mcp-chat-prompt-page --strict`.

Closes OSS-11.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
